### PR TITLE
Handle the server not sending keepalives within batch limit time

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
+++ b/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
@@ -131,6 +131,14 @@ public class NakadiClient {
 
       logger.info("Loaded resource token provider {}", resourceTokenProvider.getClass().getName());
 
+      if (metricCollector == null) {
+        metricCollector = new MetricCollectorDevnull();
+      }
+
+      logger.info("Loaded metric collector {}", metricCollector.getClass().getName());
+
+      metricCollector = new MetricCollectorSafely(metricCollector);
+
       if (resourceProvider == null) {
 
         OkHttpClient.Builder builder = new OkHttpClient.Builder()
@@ -146,14 +154,6 @@ public class NakadiClient {
         resourceProvider =
             new OkHttpResourceProvider(baseURI, builder.build(), jsonSupport, metricCollector);
       }
-
-      if (metricCollector == null) {
-        metricCollector = new MetricCollectorDevnull();
-      }
-
-      logger.info("Loaded metric collector {}", metricCollector.getClass().getName());
-
-      metricCollector = new MetricCollectorSafely(metricCollector);
 
       return new NakadiClient(this);
     }

--- a/nakadi-java-client/src/main/java/nakadi/OkHttpResponseBody.java
+++ b/nakadi-java-client/src/main/java/nakadi/OkHttpResponseBody.java
@@ -3,8 +3,13 @@ package nakadi;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class OkHttpResponseBody implements ResponseBody {
+
+  private static final Logger logger = LoggerFactory.getLogger(NakadiClient.class.getSimpleName());
+  private static final int CLOSE_ATTEMPTS = 3;
 
   private final okhttp3.Response okResponse;
 
@@ -42,6 +47,29 @@ class OkHttpResponseBody implements ResponseBody {
   }
 
   @Override public void close() throws IOException {
-    okResponse.body().close();
+    boolean closed = false;
+    try {
+      okResponse.body().close();
+      closed = true;
+    } catch (Exception e) {
+      logger.warn("okhttp_close_error problem closing on {} {}", e.getClass().getName(), e.getMessage());
+    } finally {
+      // try again, but it looks like you get one shot with okhttp, esp. for a cross thread problem
+      int attempt = 0;
+      while(!closed && attempt++ < CLOSE_ATTEMPTS) {
+        try {
+          okResponse.close();
+          closed = true;
+        } catch (Exception e1) {
+          logger.warn("okhttp_close_error retrying close attempts {}/{} on {}", attempt,
+              CLOSE_ATTEMPTS, e1.getMessage());
+        }
+      }
+
+      if(!closed) {
+        logger.error("okhttp_close_error could not close http response attempts {}/{}", attempt,
+            CLOSE_ATTEMPTS);
+      }
+    }
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/StreamExceptionSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamExceptionSupport.java
@@ -65,6 +65,13 @@ class StreamExceptionSupport {
       return false; // todo: investigate if this can be retryable
     }
 
+    if (e instanceof java.util.concurrent.TimeoutException) {
+      logger.warn(
+          "Retryable timeout exception, maybe due to the server not sending keepalives in time {}",
+          e.getMessage());
+      return true;
+    }
+
     logger.warn(
         String.format("Non-retryable exception: %s %s", e.getClass(), e.getMessage()));
 


### PR DESCRIPTION
Adds a timeout that will fire if the keepaive is not seen within
the configured (or default) batch limit time, plus a grace period.

If the TimeoutException is thrown the client will disconnect and
resume the stream by reconnecting. This protects against server
weirdness but also against half-open connections.

The observable's using() setup runs on a single threaded scheduler.
OkHttp needs to close a response on the same thread that opened it
otherwise we'll get errors and may leak resources. Using a single
thread scheduler allows that to happen whereas the default/io/compute
schedulers all use a thead pool that often has the dispose step
trying to close the OkHttp response on the wrong thread.

