### PR TITLE
Allows the eventTypeStatistic to be set on an EventType.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventType.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventType.java
@@ -159,6 +159,17 @@ public class EventType {
   }
 
   /**
+   * Set the statistic. Note this only is useful when initially creating an event type.
+   *
+   * @param eventTypeStatistic the statistic to set
+   * @return this
+   */
+  public EventType eventTypeStatistics(EventTypeStatistics eventTypeStatistic) {
+    this.defaultStatistic = eventTypeStatistic;
+    return this;
+  }
+
+  /**
    * Sets the options supported by the API. Note this will <b>replace was was previously set</b>.
    *
    * @param options the options

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeStatistics.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeStatistics.java
@@ -12,6 +12,14 @@ public class EventTypeStatistics {
   private int readParallelism;
   private int writeParallelism;
 
+  public EventTypeStatistics(int messagesPerMinute, int messageSize, int readParallelism,
+      int writeParallelism) {
+    this.messagesPerMinute = messagesPerMinute;
+    this.messageSize = messageSize;
+    this.readParallelism = readParallelism;
+    this.writeParallelism = writeParallelism;
+  }
+
   /**
    * @return the messages per minute
    */

--- a/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
@@ -12,6 +12,24 @@ public class EventTypeTest {
 
 
   @Test
+  public void testEventTypeStatisticsSerialization() {
+
+    EventType et = new EventType();
+    EventTypeStatistics ets = new EventTypeStatistics(1,2,3,4);
+
+    et.eventTypeStatistics(ets);
+
+    final NakadiClient client = TestSupport.newNakadiClient();
+    final String s = client.jsonSupport().toJson(et);
+    final EventType eventType = client.jsonSupport().fromJson(s, EventType.class);
+
+    assertEquals(1, eventType.eventTypeStatistics().messagesPerMinute());
+    assertEquals(2, eventType.eventTypeStatistics().messageSize());
+    assertEquals(3, eventType.eventTypeStatistics().readParallelism());
+    assertEquals(4, eventType.eventTypeStatistics().writeParallelism());
+  }
+
+  @Test
   public void testFields() {
 
     try {


### PR DESCRIPTION
This is useful for implicit creation of partition count and should
only be used when creating a new event type.