### PR TITLE
Makes publishing status and steps visible in BatchItemResponse.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/BatchItemResponse.java
+++ b/nakadi-java-client/src/main/java/nakadi/BatchItemResponse.java
@@ -17,6 +17,18 @@ public class BatchItemResponse {
     return publishing_status;
   }
 
+  @VisibleForTesting
+  BatchItemResponse publishingStatus(PublishingStatus publishingStatus) {
+    this.publishing_status = publishingStatus;
+    return this;
+  }
+
+  @VisibleForTesting
+  BatchItemResponse step(Step step) {
+    this.step = step;
+    return this;
+  }
+
   public Step step() {
     return step;
   }
@@ -47,11 +59,11 @@ public class BatchItemResponse {
         '}';
   }
 
-  enum PublishingStatus {
+  public enum PublishingStatus {
     failed, submitted, aborted
   }
 
-  enum Step {
+  public enum Step {
     none, validating, partitioning, enriching, publishing
   }
 }

--- a/nakadi-java-client/src/test/java/nakadi/BatchItemResponseTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/BatchItemResponseTest.java
@@ -1,0 +1,21 @@
+package nakadi;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BatchItemResponseTest {
+
+
+  @Test
+  public void statusStep() {
+
+    BatchItemResponse bir = new BatchItemResponse();
+    bir.publishingStatus(BatchItemResponse.PublishingStatus.failed);
+    bir.step(BatchItemResponse.Step.partitioning);
+
+    assertEquals(bir.publishingStatus(), BatchItemResponse.PublishingStatus.failed);
+    assertEquals(bir.step(), BatchItemResponse.Step.partitioning);
+  }
+
+}

--- a/nakadi-java-client/src/test/java/nakadi/test/BatchItemResponseVisibilityTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/test/BatchItemResponseVisibilityTest.java
@@ -1,0 +1,24 @@
+package nakadi.test;
+
+import java.util.EnumSet;
+import nakadi.BatchItemResponse;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BatchItemResponseVisibilityTest {
+
+
+  @Test
+  public void visibility_gh264() {
+    // https://github.com/dehora/nakadi-java/issues/264
+    EnumSet<BatchItemResponse.PublishingStatus> errors = EnumSet.of(
+        BatchItemResponse.PublishingStatus.failed,
+        BatchItemResponse.PublishingStatus.aborted
+    );
+
+    assertTrue(errors.size() == 2);
+  }
+
+}


### PR DESCRIPTION
For #264.