### PR TITLE
Deprecates scopes.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EmptyTokenProvider.java
+++ b/nakadi-java-client/src/main/java/nakadi/EmptyTokenProvider.java
@@ -7,7 +7,7 @@ import java.util.Optional;
  */
 public class EmptyTokenProvider implements TokenProvider {
 
-  @Override public Optional<String> authHeaderValue(String scope) {
+  @Override public Optional<String> authHeaderValue(@Deprecated String scope) {
     return Optional.empty();
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResource.java
@@ -8,11 +8,12 @@ import java.util.Map;
 public interface EventResource {
 
   /**
-   * Set the OAuth scope to be used for the request. This can be reset between requests.
+   * Deprecated since 0.9.7 and will be removed in 0.10.0. Scopes set here are ignored.
    *
    * @param scope the OAuth scope to be used for the request
    * @return this
    */
+  @Deprecated
   EventResource scope(String scope);
 
   /**

--- a/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
@@ -34,7 +34,6 @@ public class EventResourceReal implements EventResource {
 
   private final NakadiClient client;
   private final JsonSupport jsonSupport;
-  private volatile String scope;
   private volatile RetryPolicy retryPolicy;
   private volatile String flowId;
 
@@ -73,8 +72,14 @@ public class EventResourceReal implements EventResource {
     }
   }
 
+  /**
+   * Deprecated since 0.9.7 and will be removed in 0.10.0. Scopes set here are ignored.
+   *
+   * @param scope the OAuth scope to be used for the request
+   * @return this
+   */
+  @Deprecated
   @Override public EventResource scope(String scope) {
-    this.scope = scope;
     return this;
   }
 
@@ -191,7 +196,6 @@ public class EventResourceReal implements EventResource {
   private ResourceOptions options(Map<String, Object> headers) {
       final ResourceOptions options = ResourceSupport.options(APPLICATION_JSON);
       options.tokenProvider(client.resourceTokenProvider());
-      options.scope(applyScope(TokenProvider.NAKADI_EVENT_STREAM_WRITE));
       if (flowId != null) {
           options.flowId(flowId);
       }
@@ -206,7 +210,4 @@ public class EventResourceReal implements EventResource {
         .path(PATH_COLLECTION);
   }
 
-  String applyScope(String fallbackScope) {
-    return scope == null ? fallbackScope : scope;
-  }
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventType.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventType.java
@@ -1,8 +1,10 @@
 package nakadi;
 
+import com.google.common.collect.Lists;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -14,6 +16,8 @@ public class EventType {
   public static final String ENRICHMENT_METADATA = "metadata_enrichment";
   public static final String PARTITION_RANDOM = "random";
   public static final String PARTITION_HASH = "hash";
+  private static final List<String> SENTINEL_EMPTY_SCOPES =
+      Collections.unmodifiableList(Lists.newArrayList());
   private final List<String> enrichmentStrategies = new ArrayList<>();
   private String name;
   private String owningApplication;
@@ -23,8 +27,6 @@ public class EventType {
   private List<String> partitionKeyFields = new ArrayList<>();
   private EventTypeStatistics defaultStatistic;
   private EventTypeOptions options;
-  private List<String> readScopes = new ArrayList<>();
-  private List<String> writeScopes = new ArrayList<>();
   private String compatibilityMode;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;
@@ -215,42 +217,48 @@ public class EventType {
   }
 
   /**
-   * @return the allowed read scopes
+   * Deprecated since 0.9.7 and will be removed in 0.10.0.
+   *
+   * @return an empty list
    */
+  @Deprecated
   public List<String> readScopes() {
-    return readScopes;
+    return SENTINEL_EMPTY_SCOPES;
   }
 
   /**
-   * Add one or more read scopes.
-   *
+   * Deprecated since 0.9.7 and will be removed in 0.10.0.
+   * <p>
+   * Scopes have been removed in recent Nakadi versions. Scopes set here are ignored.
+   *</p>
    * @param readScopes the read scopes
    * @return this
    */
+  @Deprecated
   public EventType readScopes(String... readScopes) {
-    NakadiException.throwNonNull(readScopes, "Please provide non-null read scopes");
-    this.readScopes = Arrays.asList(readScopes);
     return this;
   }
 
   /**
-   * The allowed write scopes.
+   * Deprecated since 0.9.7 and will be removed in 0.10.0.
    *
-   * @return this
+   * @return an empty list
    */
+  @Deprecated
   public List<String> writeScopes() {
-    return writeScopes;
+    return SENTINEL_EMPTY_SCOPES;
   }
 
   /**
-   * Add one or more write scopes.
-   *
+   * Deprecated since 0.9.7 and will be removed in 0.10.0.
+   * <p>
+   * Scopes have been removed in recent Nakadi versions. Scopes set here are ignored.
+   *</p>
    * @param writeScopes the write scopes
    * @return this
    */
+  @Deprecated
   public EventType writeScopes(String... writeScopes) {
-    NakadiException.throwNonNull(writeScopes, "Please provide non-null write scopes");
-    this.writeScopes = Arrays.asList(writeScopes);
     return this;
   }
 
@@ -293,8 +301,7 @@ public class EventType {
 
   @Override public int hashCode() {
     return Objects.hash(enrichmentStrategies, name, owningApplication, category, partitionStrategy,
-        schema, partitionKeyFields, defaultStatistic, options, readScopes, writeScopes,
-        compatibilityMode);
+        schema, partitionKeyFields, defaultStatistic, options, compatibilityMode);
   }
 
   @Override public boolean equals(Object o) {
@@ -310,8 +317,6 @@ public class EventType {
         Objects.equals(partitionKeyFields, eventType.partitionKeyFields) &&
         Objects.equals(defaultStatistic, eventType.defaultStatistic) &&
         Objects.equals(options, eventType.options) &&
-        Objects.equals(readScopes, eventType.readScopes) &&
-        Objects.equals(writeScopes, eventType.writeScopes) &&
         Objects.equals(compatibilityMode, eventType.compatibilityMode);
   }
 
@@ -325,8 +330,6 @@ public class EventType {
         ", partitionKeyFields=" + partitionKeyFields +
         ", defaultStatistic=" + defaultStatistic +
         ", options=" + options +
-        ", readScopes=" + readScopes +
-        ", writeScopes=" + writeScopes +
         ", compatibilityMode='" + compatibilityMode + '\'' +
         '}';
   }

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
@@ -9,11 +9,12 @@ import java.util.Optional;
 public interface EventTypeResource {
 
   /**
-   * Set the OAuth scope to be used for the request. This can be reset between requests.
+   * Deprecated since 0.9.7 and will be removed in 0.10.0. Scopes set here are ignored.
    *
    * @param scope the OAuth scope to be used for the request
    * @return this
    */
+  @Deprecated
   EventTypeResource scope(String scope);
 
   /**

--- a/nakadi-java-client/src/main/java/nakadi/ResourceOptions.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceOptions.java
@@ -9,7 +9,6 @@ class ResourceOptions {
   //multimap would be correct, but a client for this api doesn't setting multiple same headers
   private final Map<String, Object> headers = new HashMap<>();
   private TokenProvider provider;
-  private String scope = TokenProvider.UID;
 
   public ResourceOptions tokenProvider(TokenProvider provider) {
     NakadiException.throwNonNull(provider, "Please provide a TokenProvider");
@@ -30,9 +29,17 @@ class ResourceOptions {
     return this;
   }
 
+  /**
+   * Deprecated since 0.9.7 and will be removed in 0.10.0.
+   *
+   * <p>
+   * Scopes have been removed in recent Nakadi versions. Scopes set here are ignored.
+   * </p>
+   * @param scope
+   * @return this
+   */
+  @Deprecated
   public ResourceOptions scope(String scope) {
-    NakadiException.throwNonNull(scope, "Please provide a scope");
-    this.scope = scope;
     return this;
   }
 
@@ -46,10 +53,19 @@ class ResourceOptions {
   }
 
   public Optional<String> supplyToken() {
-    return provider.authHeaderValue(this.scope);
+    return provider.authHeaderValue(null);
   }
 
+  /**
+   * Deprecated since 0.9.7 and will be removed in 0.10.0.
+   *
+   * <p>
+   * Scopes have been removed in recent Nakadi versions. This always returns null.
+   * </p>
+   * @return null
+   */
+  @Deprecated
   public String scope() {
-    return scope;
+    return null;
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -47,7 +47,6 @@ public class StreamProcessor implements StreamProcessorManaged {
   private final JsonBatchSupport jsonBatchSupport;
   private final long maxRetryDelay;
   private final int maxRetryAttempts;
-  private final String scope;
   // non builder supplied
   private final AtomicBoolean started = new AtomicBoolean(false);
   private final AtomicBoolean stopped = new AtomicBoolean(false);
@@ -81,7 +80,6 @@ public class StreamProcessor implements StreamProcessorManaged {
     this.jsonBatchSupport = new JsonBatchSupport(client.jsonSupport());
     this.maxRetryDelay = StreamConnectionRetryFlowable.DEFAULT_MAX_DELAY_SECONDS;
     this.maxRetryAttempts = StreamConnectionRetryFlowable.DEFAULT_MAX_ATTEMPTS;
-    this.scope = null;
     startLatch = new CountDownLatch(1);
     this.streamProcessorRequestFactory = streamProcessorRequestFactory;
   }
@@ -94,7 +92,6 @@ public class StreamProcessor implements StreamProcessorManaged {
     this.jsonBatchSupport = new JsonBatchSupport(client.jsonSupport());
     this.maxRetryDelay = streamConfiguration.maxRetryDelaySeconds();
     this.maxRetryAttempts = streamConfiguration.maxRetryAttempts();
-    this.scope = builder.scope;
     startLatch = new CountDownLatch(1);
     this.streamProcessorRequestFactory = builder.streamProcessorRequestFactory;
   }
@@ -499,7 +496,6 @@ public class StreamProcessor implements StreamProcessorManaged {
     private SubscriptionOffsetCheckpointer checkpointer;
     private StreamOffsetObserver streamOffsetObserver;
     private StreamConfiguration streamConfiguration;
-    private String scope;
     private StreamProcessorRequestFactory streamProcessorRequestFactory;
 
     public Builder() {
@@ -537,11 +533,9 @@ public class StreamProcessor implements StreamProcessorManaged {
         this.streamOffsetObserver = new LoggingStreamOffsetObserver();
       }
 
-      this.scope =
-          Optional.ofNullable(scope).orElse(TokenProvider.NAKADI_EVENT_STREAM_READ);
 
       if (streamProcessorRequestFactory == null) {
-        streamProcessorRequestFactory = new StreamProcessorRequestFactory(client, scope);
+        streamProcessorRequestFactory = new StreamProcessorRequestFactory(client);
       }
 
       return new StreamProcessor(this);
@@ -552,8 +546,13 @@ public class StreamProcessor implements StreamProcessorManaged {
       return this;
     }
 
+    /**
+     * Deprecated since 0.9.7 and will be removed in 0.10.0. Scopes set here are ignored.
+     *
+     * @return this
+     */
+    @Deprecated
     public Builder scope(String scope) {
-      this.scope = scope;
       return this;
     }
 

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessorRequestFactory.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessorRequestFactory.java
@@ -10,11 +10,9 @@ class StreamProcessorRequestFactory {
   private static final Logger logger = LoggerFactory.getLogger(NakadiClient.class.getSimpleName());
 
   private final NakadiClient client;
-  private final String scope;
 
-  StreamProcessorRequestFactory(NakadiClient client, String scope) {
+  StreamProcessorRequestFactory(NakadiClient client) {
     this.client = client;
-    this.scope = scope;
   }
 
   Callable<Response> createCallable(StreamConfiguration sc, StreamProcessor streamProcessor) {
@@ -24,11 +22,10 @@ class StreamProcessorRequestFactory {
   @SuppressWarnings("WeakerAccess") @VisibleForTesting
   Response onCall(StreamConfiguration sc, StreamProcessor streamProcessor) throws Exception {
     final String url = StreamResourceSupport.buildStreamUrl(client.baseURI(), sc);
-    ResourceOptions options = StreamResourceSupport.buildResourceOptions(client, sc, scope);
-    logger.info("stream_connection_open step=details mode={} url={} scope={}",
+    ResourceOptions options = StreamResourceSupport.buildResourceOptions(client, sc);
+    logger.info("stream_connection_open step=details mode={} url={}",
         sc.isEventTypeStream() ? "eventStream" : "subscriptionStream",
-        url,
-        options.scope());
+        url);
 
     final Response response = requestStreamConnection(url, options, buildResource(sc));
     logger.info("stream_connection_open step=opened {} {}", response.hashCode(), response);

--- a/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
@@ -44,12 +44,10 @@ class StreamResourceSupport {
    * single line JSON encoding of {@link StreamConfiguration#cursors()} if the configuration
    * is a basic event stream.
    */
-  static ResourceOptions buildResourceOptions(NakadiClient client, StreamConfiguration sc,
-      String scope) {
+  static ResourceOptions buildResourceOptions(NakadiClient client, StreamConfiguration sc) {
     ResourceOptions options = ResourceSupport
         // breaks with api definition https://github.com/zalando-incubator/nakadi-java/issues/98
         .options(APPLICATION_JSON)
-        .scope(Optional.ofNullable(scope).orElse(TokenProvider.NAKADI_EVENT_STREAM_READ))
         .tokenProvider(client.resourceTokenProvider());
 
     applyConfiguredHeaders(sc, options);

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResource.java
@@ -10,11 +10,11 @@ import java.util.Optional;
 public interface SubscriptionResource {
 
   /**
-   * Set the OAuth scope to be used for the request. This can be reset between requests.
+   * Deprecated since 0.9.7 and will be removed in 0.10.0. Scopes set here are ignored.
    *
-   * @param scope the OAuth scope to be used for the request
    * @return this
    */
+  @Deprecated
   SubscriptionResource scope(String scope);
 
   /**

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
@@ -28,7 +28,6 @@ class SubscriptionResourceReal implements SubscriptionResource {
 
   private final NakadiClient client;
   private CursorCommitResultCollection sentinelCursorCommitResultCollection;
-  private String scope;
   private volatile RetryPolicy retryPolicy;
 
   SubscriptionResourceReal(NakadiClient client) {
@@ -51,8 +50,13 @@ class SubscriptionResourceReal implements SubscriptionResource {
     }
   }
 
+  /**
+   * Deprecated since 0.9.7 and will be removed in 0.10.0. Scopes set here are ignored.
+   *
+   * @return this
+   */
+  @Deprecated
   @Override public SubscriptionResource scope(String scope) {
-    this.scope = scope;
     return this;
   }
 
@@ -66,7 +70,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       RateLimitException, NakadiException {
     //todo:filebug: nakadi.event_stream.read is in the yaml but this is a write action
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = prepareOptions();
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -78,7 +82,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, ConflictException, NakadiException {
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = prepareOptions();
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -91,7 +95,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       RateLimitException, NakadiException {
     NakadiException.throwNonNull(id, "Please provide an id");
     String url = collectionUri().path(id).buildString();
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = prepareOptions();
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -126,8 +130,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       RateLimitException, NakadiException {
     NakadiException.throwNonNull(id, "Please provide an id");
     String url = collectionUri().path(id).buildString();
-    // todo:filebug: no delete operation in yaml, got with config write as per event type delete
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_CONFIG_WRITE);
+    ResourceOptions options = prepareOptions();
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -186,8 +189,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
         .path(SubscriptionResourceReal.PATH_CURSORS)
         .buildString();
 
-    // todo:filebug: 'nakadi.event_stream.read' in yaml but this is a write method
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = prepareOptions();
 
     options.header(StreamResourceSupport.X_NAKADI_STREAM_ID, streamId);
 
@@ -217,7 +219,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
   }
 
   SubscriptionEventTypeStatsCollection loadStatsPage(String url) {
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = prepareOptions();
     Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -235,7 +237,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
   }
 
   SubscriptionCursorCollection loadCursorPage(String url) {
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = prepareOptions();
     Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -253,7 +255,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
   }
 
   SubscriptionCollection loadPage(String url) {
-    ResourceOptions options = this.prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = this.prepareOptions();
     Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -276,7 +278,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
     final Resource resource = client.resourceProvider().newResource().retryPolicy(retryPolicy);
     final String url = collectionUri().path(id).path(PATH_CURSORS).buildString();
     // read scope: see https://github.com/zalando/nakadi/issues/648
-    final ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    final ResourceOptions options = prepareOptions();
     final List<Cursor> cleaned = Cursor.prepareRequiringEventType(cursors);
 
     return timed(() ->
@@ -302,9 +304,8 @@ class SubscriptionResourceReal implements SubscriptionResource {
     return subscriptions;
   }
 
-  private ResourceOptions prepareOptions(String fallbackScope) {
+  private ResourceOptions prepareOptions() {
     return ResourceSupport.options(APPLICATION_JSON)
-        .scope(Optional.ofNullable(scope).orElse(fallbackScope))
         .tokenProvider(client.resourceTokenProvider());
   }
 
@@ -318,7 +319,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
 
   private List<CursorCommitResult> loadCollection(String url) {
 
-    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    ResourceOptions options = prepareOptions();
     Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)

--- a/nakadi-java-client/src/main/java/nakadi/TokenProvider.java
+++ b/nakadi-java-client/src/main/java/nakadi/TokenProvider.java
@@ -10,15 +10,14 @@ import java.util.Optional;
 @FunctionalInterface
 public interface TokenProvider {
 
-  String NAKADI_CONFIG_WRITE = "nakadi.config.write";
-  String NAKADI_EVENT_TYPE_WRITE = "nakadi.event_type.write";
-  String NAKADI_EVENT_STREAM_WRITE = "nakadi.event_stream.write";
-  String NAKADI_EVENT_STREAM_READ = "nakadi.event_stream.read";
-  String UID = "uid";
-
   /**
+   * <p>
+   * Scopes have been removed in recent Nakadi versions. Scopes set here are ignored.
+   * </p>
+   *
    * @return a value suitable for use in an Authorization header, or null to suppress the
    * Authorization header being set
    */
-  Optional<String> authHeaderValue(String scope);
+  Optional<String> authHeaderValue(@Deprecated String scope);
+
 }

--- a/nakadi-java-client/src/test/java/nakadi/EventTypeResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventTypeResourceRealTest.java
@@ -14,6 +14,7 @@ import org.mockito.Matchers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -188,25 +189,17 @@ public class EventTypeResourceRealTest {
   }
 
   @Test
-  public void createWithScope() {
+  public void createNoScope() {
 
     EventType et2 = buildEventType();
-
-    final boolean[] askedForNAKADI_EVENT_TYPE_WRITE = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
 
     NakadiClient client = spy(NakadiClient.newBuilder()
         .baseURI("http://localhost:9081")
         .tokenProvider(scope -> {
-          if (TokenProvider.NAKADI_EVENT_TYPE_WRITE.equals(scope)) {
-            askedForNAKADI_EVENT_TYPE_WRITE[0] = true;
-          }
 
-          if (customScope.equals(scope)) {
-            askedForCustomToken[0] = true;
+          if (scope != null) {
+            throw new AssertionError("scope should not be called");
           }
-
           return Optional.empty();
         })
         .build());
@@ -234,9 +227,7 @@ public class EventTypeResourceRealTest {
         Matchers.any(ContentSupplier.class)
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_TYPE_WRITE, options.getValue().scope());
-    assertTrue(askedForNAKADI_EVENT_TYPE_WRITE[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -248,7 +239,6 @@ public class EventTypeResourceRealTest {
 
     try {
       new EventTypeResourceReal(client)
-          .scope(customScope)
           .update(et2);
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -262,30 +252,21 @@ public class EventTypeResourceRealTest {
         Matchers.any(ContentSupplier.class)
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertTrue(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void updateWithScope() {
+  public void updateNoScope() {
 
     EventType et2 = buildEventType();
-
-    final boolean[] askedForNAKADI_EVENT_TYPE_WRITE = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
 
     NakadiClient client = spy(NakadiClient.newBuilder()
         .baseURI("http://localhost:9081")
         .tokenProvider(scope -> {
-          if (TokenProvider.NAKADI_EVENT_TYPE_WRITE.equals(scope)) {
-            askedForNAKADI_EVENT_TYPE_WRITE[0] = true;
-          }
 
-          if (customScope.equals(scope)) {
-            askedForCustomToken[0] = true;
+          if (scope != null) {
+            throw new AssertionError("scope should not be called");
           }
-
           return Optional.empty();
         })
         .build());
@@ -313,9 +294,7 @@ public class EventTypeResourceRealTest {
         Matchers.any(ContentSupplier.class)
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_TYPE_WRITE, options.getValue().scope());
-    assertTrue(askedForNAKADI_EVENT_TYPE_WRITE[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -327,7 +306,6 @@ public class EventTypeResourceRealTest {
 
     try {
       new EventTypeResourceReal(client)
-          .scope(customScope)
           .create(et2);
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -341,8 +319,7 @@ public class EventTypeResourceRealTest {
         Matchers.any(ContentSupplier.class)
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertTrue(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
   }
 
   private EventType buildEventType() {
@@ -358,21 +335,13 @@ public class EventTypeResourceRealTest {
   }
 
   @Test
-  public void listWithScope() {
-
-    final boolean[] askedForNAKADI_EVENT_STREAM_READ = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
+  public void listNoScope() {
 
     NakadiClient client = spy(NakadiClient.newBuilder()
         .baseURI("http://localhost:9081")
         .tokenProvider(scope -> {
-          if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
-            askedForNAKADI_EVENT_STREAM_READ[0] = true;
-          }
-
-          if (customScope.equals(scope)) {
-            askedForCustomToken[0] = true;
+          if (scope != null) {
+            throw new AssertionError("scope should not be called");
           }
 
           return Optional.empty();
@@ -400,9 +369,7 @@ public class EventTypeResourceRealTest {
         options.capture()
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
-    assertTrue(askedForNAKADI_EVENT_STREAM_READ[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -413,7 +380,7 @@ public class EventTypeResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      new EventTypeResourceReal(client).scope(customScope).list();
+      new EventTypeResourceReal(client).list();
     } catch (RetryableException | NotFoundException ignored) {
     }
 
@@ -424,26 +391,18 @@ public class EventTypeResourceRealTest {
         Matchers.eq("http://localhost:9081/event-types"),
         options.capture());
 
-    assertEquals(customScope, options.getValue().scope());
-    assertTrue(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void findWithScope() {
-
-    final boolean[] askedForNAKADI_EVENT_STREAM_READ = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
+  public void findNoScope() {
 
     NakadiClient client = spy(NakadiClient.newBuilder()
         .baseURI("http://localhost:9081")
         .tokenProvider(scope -> {
-          if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
-            askedForNAKADI_EVENT_STREAM_READ[0] = true;
-          }
 
-          if (customScope.equals(scope)) {
-            askedForCustomToken[0] = true;
+          if (scope != null) {
+            throw new AssertionError("scope should not be called");
           }
 
           return Optional.empty();
@@ -459,9 +418,6 @@ public class EventTypeResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      assertFalse(askedForCustomToken[0]);
-      assertFalse(askedForNAKADI_EVENT_STREAM_READ[0]);
-
       new EventTypeResourceReal(client)
           .findByName("foo");
     } catch (RetryableException | NotFoundException ignored) {
@@ -477,9 +433,7 @@ public class EventTypeResourceRealTest {
         options.capture(),
         Matchers.eq(EventType.class));
 
-    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
-    assertFalse(askedForCustomToken[0]);
-    assertTrue(askedForNAKADI_EVENT_STREAM_READ[0]);
+    assertNull(options.getValue().scope());
 
     Resource r2 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -490,11 +444,7 @@ public class EventTypeResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r2);
 
     try {
-      askedForCustomToken[0] = false;
-      assertFalse(askedForCustomToken[0]);
-
       new EventTypeResourceReal(client)
-          .scope(customScope)
           .findByName("foo");
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -507,26 +457,17 @@ public class EventTypeResourceRealTest {
         options.capture(),
         Matchers.eq(EventType.class));
 
-    assertEquals(customScope, options.getValue().scope());
-    assertTrue(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void deleteWithScope() {
-
-    final boolean[] askedForNAKADI_CONFIG_WRITE = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
+  public void deleteNoScope() {
 
     NakadiClient client = spy(NakadiClient.newBuilder()
         .baseURI("http://localhost:9081")
         .tokenProvider(scope -> {
-          if (TokenProvider.NAKADI_CONFIG_WRITE.equals(scope)) {
-            askedForNAKADI_CONFIG_WRITE[0] = true;
-          }
-
-          if (customScope.equals(scope)) {
-            askedForCustomToken[0] = true;
+          if (scope != null) {
+            throw new AssertionError("scope should not be called");
           }
 
           return Optional.empty();
@@ -542,9 +483,6 @@ public class EventTypeResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      assertFalse(askedForCustomToken[0]);
-      assertFalse(askedForNAKADI_CONFIG_WRITE[0]);
-
       new EventTypeResourceReal(client).delete("foo");
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -558,9 +496,7 @@ public class EventTypeResourceRealTest {
         Matchers.eq("http://localhost:9081/event-types/foo"),
         options.capture());
 
-    assertEquals(TokenProvider.NAKADI_CONFIG_WRITE, options.getValue().scope());
-    assertFalse(askedForCustomToken[0]);
-    assertTrue(askedForNAKADI_CONFIG_WRITE[0]);
+    assertNull(options.getValue().scope());
 
     Resource r2 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -571,11 +507,8 @@ public class EventTypeResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r2);
 
     try {
-      askedForCustomToken[0] = false;
-      assertFalse(askedForCustomToken[0]);
 
       new EventTypeResourceReal(client)
-          .scope(customScope)
           .delete("foo");
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -587,7 +520,6 @@ public class EventTypeResourceRealTest {
         Matchers.eq("http://localhost:9081/event-types/foo"),
         options.capture());
 
-    assertEquals(customScope, options.getValue().scope());
-    assertTrue(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
   }
 }

--- a/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
@@ -41,8 +41,6 @@ public class EventTypeTest {
       et.owningApplication("dd");
       et.partitionStrategy("dd");
       et.partitionKeyFields("dd");
-      et.readScopes("a");
-      et.writeScopes("a");
       et.schema(new EventTypeSchema());
     } catch (Exception e) {
       fail("broken field check " +e.getMessage());

--- a/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -19,30 +20,26 @@ public class StreamResourceSupportTest {
       NakadiClient.newBuilder().baseURI(baseUrl()).build();
 
   @Test
-  public void testScope() {
+  public void testNoScope() {
 
-    assertEquals(
-        TokenProvider.NAKADI_EVENT_STREAM_READ,
+    assertNull(
         StreamResourceSupport.buildResourceOptions(client,
-            new StreamConfiguration().eventTypeName("et"), null).scope()
+            new StreamConfiguration().eventTypeName("et")).scope()
     );
 
-    assertEquals(
-        TokenProvider.NAKADI_EVENT_STREAM_READ,
+    assertNull(
         StreamResourceSupport.buildResourceOptions(client,
-            new StreamConfiguration().subscriptionId("sub1"), null).scope()
+            new StreamConfiguration().subscriptionId("sub1")).scope()
     );
 
-    assertEquals(
-        "custom",
+    assertNull(
         StreamResourceSupport.buildResourceOptions(client,
-            new StreamConfiguration().eventTypeName("et"), "custom").scope()
+            new StreamConfiguration().eventTypeName("et")).scope()
     );
 
-    assertEquals(
-        "custom",
+    assertNull(
         StreamResourceSupport.buildResourceOptions(client,
-            new StreamConfiguration().subscriptionId("sub1"), "custom").scope()
+            new StreamConfiguration().subscriptionId("sub1")).scope()
     );
   }
 
@@ -141,7 +138,7 @@ public class StreamResourceSupportTest {
         NakadiClient.newBuilder().baseURI(baseUrl()).build();
 
     final ResourceOptions resourceOptions =
-        StreamResourceSupport.buildResourceOptions(client, sc, null);
+        StreamResourceSupport.buildResourceOptions(client, sc);
 
     assertTrue(resourceOptions.headers().containsKey("Accept-Encoding"));
   }

--- a/nakadi-java-client/src/test/java/nakadi/SubscriptionResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/SubscriptionResourceRealTest.java
@@ -19,6 +19,7 @@ import org.mockito.Matchers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -122,21 +123,13 @@ public class SubscriptionResourceRealTest {
   }
 
   @Test
-  public void listWithScope() {
-    final boolean[] askedForDefaultToken = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
-
+  public void listWithNoScope() {
     NakadiClient client =
         spy(NakadiClient.newBuilder()
             .baseURI("http://localhost:9081")
             .tokenProvider(scope -> {
-              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
-                askedForDefaultToken[0] = true;
-              }
-
-              if (customScope.equals(scope)) {
-                askedForCustomToken[0] = true;
+              if (scope != null) {
+                throw new AssertionError("scope should not be called");
               }
 
               return Optional.empty();
@@ -165,9 +158,7 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
-    assertTrue(askedForDefaultToken[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -178,13 +169,8 @@ public class SubscriptionResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      askedForDefaultToken[0] = false;
-      askedForCustomToken[0] = false;
-      assertFalse(askedForDefaultToken[0]);
-      assertFalse(askedForCustomToken[0]);
 
       new SubscriptionResourceReal(client)
-          .scope(customScope)
           .list();
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -197,29 +183,19 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertFalse(askedForDefaultToken[0]);
-    assertTrue(askedForCustomToken[0]);
-
-
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void findWithScope() {
-    final boolean[] askedForDefaultToken = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
+  public void findWithNoScope() {
 
     NakadiClient client =
         spy(NakadiClient.newBuilder()
             .baseURI("http://localhost:9081")
             .tokenProvider(scope -> {
-              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
-                askedForDefaultToken[0] = true;
-              }
 
-              if (customScope.equals(scope)) {
-                askedForCustomToken[0] = true;
+              if (scope != null) {
+                throw new AssertionError("scope should not be called");
               }
 
               return Optional.empty();
@@ -249,9 +225,7 @@ public class SubscriptionResourceRealTest {
         Matchers.eq(Subscription.class)
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
-    assertTrue(askedForDefaultToken[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -262,13 +236,7 @@ public class SubscriptionResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      askedForDefaultToken[0] = false;
-      askedForCustomToken[0] = false;
-      assertFalse(askedForDefaultToken[0]);
-      assertFalse(askedForCustomToken[0]);
-
       new SubscriptionResourceReal(client)
-          .scope(customScope)
           .find("sid");
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -282,29 +250,18 @@ public class SubscriptionResourceRealTest {
         Matchers.eq(Subscription.class)
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertFalse(askedForDefaultToken[0]);
-    assertTrue(askedForCustomToken[0]);
-
-
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void cursorsWithScope() {
-    final boolean[] askedForDefaultToken = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
-
+  public void cursorsWithNoScope() {
     NakadiClient client =
         spy(NakadiClient.newBuilder()
             .baseURI("http://localhost:9081")
             .tokenProvider(scope -> {
-              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
-                askedForDefaultToken[0] = true;
-              }
 
-              if (customScope.equals(scope)) {
-                askedForCustomToken[0] = true;
+              if (scope != null) {
+                throw new AssertionError("scope should not be called");
               }
 
               return Optional.empty();
@@ -333,9 +290,7 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
-    assertTrue(askedForDefaultToken[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -346,13 +301,7 @@ public class SubscriptionResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      askedForDefaultToken[0] = false;
-      askedForCustomToken[0] = false;
-      assertFalse(askedForDefaultToken[0]);
-      assertFalse(askedForCustomToken[0]);
-
       new SubscriptionResourceReal(client)
-          .scope(customScope)
           .cursors("sid");
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -365,29 +314,18 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertFalse(askedForDefaultToken[0]);
-    assertTrue(askedForCustomToken[0]);
-
-
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void statsWithScope() {
-    final boolean[] askedForDefaultToken = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
+  public void statsWithNoScope() {
 
     NakadiClient client =
         spy(NakadiClient.newBuilder()
             .baseURI("http://localhost:9081")
             .tokenProvider(scope -> {
-              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
-                askedForDefaultToken[0] = true;
-              }
-
-              if (customScope.equals(scope)) {
-                askedForCustomToken[0] = true;
+              if (scope != null) {
+                throw new AssertionError("scope should not be called");
               }
 
               return Optional.empty();
@@ -416,9 +354,7 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
-    assertTrue(askedForDefaultToken[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -429,13 +365,7 @@ public class SubscriptionResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      askedForDefaultToken[0] = false;
-      askedForCustomToken[0] = false;
-      assertFalse(askedForDefaultToken[0]);
-      assertFalse(askedForCustomToken[0]);
-
       new SubscriptionResourceReal(client)
-          .scope(customScope)
           .stats("sid");
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -448,29 +378,17 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertFalse(askedForDefaultToken[0]);
-    assertTrue(askedForCustomToken[0]);
-
-
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void deleteWithScope() {
-    final boolean[] askedForDefaultToken = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
-
+  public void deleteWithNoScope() {
     NakadiClient client =
         spy(NakadiClient.newBuilder()
             .baseURI("http://localhost:9081")
             .tokenProvider(scope -> {
-              if (TokenProvider.NAKADI_CONFIG_WRITE.equals(scope)) {
-                askedForDefaultToken[0] = true;
-              }
-
-              if (customScope.equals(scope)) {
-                askedForCustomToken[0] = true;
+              if (scope != null) {
+                throw new AssertionError("scope should not be called");
               }
 
               return Optional.empty();
@@ -499,9 +417,7 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(TokenProvider.NAKADI_CONFIG_WRITE, options.getValue().scope());
-    assertTrue(askedForDefaultToken[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -512,13 +428,7 @@ public class SubscriptionResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      askedForDefaultToken[0] = false;
-      askedForCustomToken[0] = false;
-      assertFalse(askedForDefaultToken[0]);
-      assertFalse(askedForCustomToken[0]);
-
       new SubscriptionResourceReal(client)
-          .scope(customScope)
           .delete("id");
     } catch (RetryableException | NotFoundException ignored) {
     }
@@ -531,19 +441,11 @@ public class SubscriptionResourceRealTest {
         options.capture()
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertFalse(askedForDefaultToken[0]);
-    assertTrue(askedForCustomToken[0]);
-
-
+    assertNull(options.getValue().scope());
   }
 
   @Test
-  public void createWithScope() {
-    final boolean[] askedForDefaultToken = {false};
-    final boolean[] askedForCustomToken = {false};
-    String customScope = "custom";
-
+  public void createWithNoScope() {
     Subscription subscription = new Subscription()
         .consumerGroup("mccaffrey-cg")
         .eventType("priority-requisitions")
@@ -553,12 +455,9 @@ public class SubscriptionResourceRealTest {
         spy(NakadiClient.newBuilder()
             .baseURI("http://localhost:9081")
             .tokenProvider(scope -> {
-              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
-                askedForDefaultToken[0] = true;
-              }
 
-              if (customScope.equals(scope)) {
-                askedForCustomToken[0] = true;
+              if (scope != null) {
+                throw new AssertionError("scope should not be called");
               }
 
               return Optional.empty();
@@ -590,9 +489,7 @@ public class SubscriptionResourceRealTest {
         Matchers.any(ContentSupplier.class)
     );
 
-    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
-    assertTrue(askedForDefaultToken[0]);
-    assertFalse(askedForCustomToken[0]);
+    assertNull(options.getValue().scope());
 
     Resource r1 = spy(new OkHttpResource(
         new OkHttpClient.Builder().build(),
@@ -603,14 +500,8 @@ public class SubscriptionResourceRealTest {
     when(client.resourceProvider().newResource()).thenReturn(r1);
 
     try {
-      askedForDefaultToken[0] = false;
-      askedForCustomToken[0] = false;
-      assertFalse(askedForDefaultToken[0]);
-      assertFalse(askedForCustomToken[0]);
-
 
       new SubscriptionResourceReal(client)
-          .scope(customScope)
           .createReturningResponse(subscription);
 
     } catch (RetryableException | NotFoundException ignored) {
@@ -625,11 +516,7 @@ public class SubscriptionResourceRealTest {
         Matchers.any(ContentSupplier.class)
     );
 
-    assertEquals(customScope, options.getValue().scope());
-    assertFalse(askedForDefaultToken[0]);
-    assertTrue(askedForCustomToken[0]);
-
-
+    assertNull(options.getValue().scope());
   }
 
 }

--- a/nakadi-java-zign/src/test/java/nakadi/token/zign/TokenProviderZignTest.java
+++ b/nakadi-java-zign/src/test/java/nakadi/token/zign/TokenProviderZignTest.java
@@ -17,8 +17,8 @@ public class TokenProviderZignTest {
     try {
       //noinspection ConfusingArgumentToVarargsMethod
       TokenProviderZign.newBuilder().scopes(null);
-      fail();
     } catch (IllegalArgumentException ignored) {
+      fail();
     }
 
     try {


### PR DESCRIPTION
This deprecates scopes on the client API. Scopes that are passed to the
client are ignored.

Nakadi removed scopes in https://github.com/zalando/nakadi/pull/722

For #228.