### PR TITLE
Removes duplicate Observer onStart call.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamBatchRecordSubscriber.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamBatchRecordSubscriber.java
@@ -20,7 +20,8 @@ class StreamBatchRecordSubscriber<T> extends ResourceSubscriber<StreamBatchRecor
 
   @Override protected void onStart() {
     super.onStart();
-    observer.onStart();
+    logger.debug("StreamBatchRecordSubscriber.onStart");
+    observer.onBegin();
   }
 
   @Override public void onNext(StreamBatchRecord<T> record) {

--- a/nakadi-java-client/src/main/java/nakadi/StreamObserver.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamObserver.java
@@ -14,6 +14,13 @@ import java.util.Optional;
 public interface StreamObserver<T> {
 
   /**
+   * Called when the stream processor is initially setup.
+   */
+  default void onBegin() {
+
+  }
+
+  /**
    * Called before stream connection begins and every time a retry is made.
    * Implementations can set up here.
    */


### PR DESCRIPTION
This replaces the onStart call when the consumer processor is setup with
a new onBegin method. The onStart should be called every time the
processor retries, but onBegin just once, avoiding a double call the
first time the processor spins up.