### PR TITLE
Adds a close method to the Response interface.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
@@ -145,17 +145,14 @@ public class EventResourceReal implements EventResource {
 
   @Override public <T> BatchItemResponseCollection sendBatch(String eventTypeName, List<T> events,
       Map<String, Object> headers) {
-    Response send = send(eventTypeName, events, headers);
-    List<BatchItemResponse> items = Lists.newArrayList();
 
-    if (send.statusCode() == 207 || send.statusCode() == 422) {
-      try (ResponseBody responseBody = send.responseBody()) {
+    List<BatchItemResponse> items = Lists.newArrayList();
+    try (Response send = send(eventTypeName, events, headers)) {
+      if (send.statusCode() == 207 || send.statusCode() == 422) {
+        ResponseBody responseBody = send.responseBody();
         items.addAll(jsonSupport.fromJson(responseBody.asReader(), TYPE_BIR));
-      } catch (IOException e) {
-        logger.error("Error handling BatchItemResponse " + e.getMessage(), e);
       }
     }
-
     return new BatchItemResponseCollection(items, LINKS_SENTINEL, client);
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/OkHttpResponse.java
+++ b/nakadi-java-client/src/main/java/nakadi/OkHttpResponse.java
@@ -1,10 +1,16 @@
 package nakadi;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import okhttp3.internal.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class OkHttpResponse implements Response {
+
+  private static final Logger logger = LoggerFactory.getLogger(NakadiClient.class.getSimpleName());
 
   private final okhttp3.Response okResponse;
 
@@ -26,6 +32,16 @@ class OkHttpResponse implements Response {
 
   @Override public ResponseBody responseBody() {
     return new OkHttpResponseBody(okResponse);
+  }
+
+  @Override public void close() {
+    try {
+      responseBody().close();
+    } catch (RuntimeException rethrow) {
+      throw rethrow;
+    } catch (Exception suppressed) {
+      logger.warn("exception closing http response {}", suppressed.getMessage());
+    }
   }
 
   @Override public int hashCode() {

--- a/nakadi-java-client/src/main/java/nakadi/OkHttpResponseBody.java
+++ b/nakadi-java-client/src/main/java/nakadi/OkHttpResponseBody.java
@@ -50,12 +50,12 @@ class OkHttpResponseBody implements ResponseBody {
   @Override public void close() throws IOException {
     boolean closed = false;
     try {
-      logger.info("response_close_ask thread={}", Thread.currentThread().getName());
+      logger.debug("response_close_ask thread={}", Thread.currentThread().getName());
       okResponse.body().close();
-      logger.info("response_close_ok thread={}", Thread.currentThread().getName());
+      logger.debug("response_close_ok thread={}", Thread.currentThread().getName());
       closed = true;
     } catch (Exception e) {
-      logger.warn("response_close_error problem closing on {} {}", e.getClass().getName(),
+      logger.error("response_close_error problem closing on {} {}", e.getClass().getName(),
           e.getMessage());
     } finally {
       // try again, but it looks like you get one shot with okhttp, esp. for a cross thread problem
@@ -65,7 +65,7 @@ class OkHttpResponseBody implements ResponseBody {
           okResponse.close();
           closed = true;
         } catch (Exception e1) {
-          logger.warn("response_close_error retrying close attempts {}/{} on {}", attempt,
+          logger.error("response_close_error retrying close attempts {}/{} on {}", attempt,
               CLOSE_ATTEMPTS, e1.getMessage());
         }
       }

--- a/nakadi-java-client/src/main/java/nakadi/Response.java
+++ b/nakadi-java-client/src/main/java/nakadi/Response.java
@@ -1,12 +1,13 @@
 package nakadi;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 
 /**
  * An abstraction of the HTTP response from the server.
  */
-public interface Response {
+public interface Response extends Closeable {
 
   /**
    * The HTTP status code
@@ -35,4 +36,11 @@ public interface Response {
    * @return the {@link ResponseBody}
    */
   ResponseBody responseBody();
+
+  /**
+   * Closes the response. Applications should call this, or
+   * {@link ResponseBody#close()} to ensure underlying connections
+   * are released.
+   */
+  void close();
 }

--- a/nakadi-java-client/src/test/java/nakadi/ProblemSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ProblemSupportTest.java
@@ -44,6 +44,14 @@ public class ProblemSupportTest {
         return null;
       }
 
+      @Override public void close() {
+        try {
+          responseBody().close();
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }
+
       @Override public ResponseBody responseBody() {
         return new ResponseBody() {
           @Override public String asString() throws ContractRetryableException {


### PR DESCRIPTION
A convenience method that delegates to the ResponseBody close
method. This might make it more obvious that Responses should
be closed by callers and is cleaner to use in a try with
resources block.

For #237.