### PR TITLE
Reduce allocations when marshalling events from a stream.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;


### PR DESCRIPTION
This removes a conversion from a JsonObject to a String, and uses the
JsonObject directly for object marshalling. It also makes a best
effort to clear down an interm list of temp objects created during
marshalling.

It's not clear if client allocations are the cause of OOMs in #256 
but this seems like a reasonable overhead to avoid.

For #256.