### PR TITLE
Stops stream processor after retries are exceeded.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamConnectionRetryFlowable.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamConnectionRetryFlowable.java
@@ -60,6 +60,8 @@ public class StreamConnectionRetryFlowable implements
             "stream_retry failed after %d attempts, propagating error %s, %s",
             backoff.workingAttempts(), throwable.getClass().getSimpleName(),
             throwable.getMessage()));
+        streamProcessor.retryAttemptsFinished(true);
+        streamProcessor.failedProcessorException(throwable);
         return Flowable.error(throwable);
       } else {
         final long delay = backoff.nextBackoffMillis();
@@ -68,6 +70,8 @@ public class StreamConnectionRetryFlowable implements
               "stream_retry being stopped after %d attempts, propagating error %s, %s",
               backoff.workingAttempts(), throwable.getClass().getSimpleName(),
               throwable.getMessage()));
+          streamProcessor.failedProcessorException(throwable);
+          streamProcessor.retryAttemptsFinished(true);
           return Flowable.error(throwable);
         }
 

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessorManaged.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessorManaged.java
@@ -8,4 +8,8 @@ interface StreamProcessorManaged {
 
   boolean running();
 
+  void retryAttemptsFinished(boolean completed);
+
+  void failedProcessorException(Throwable t);
+
 }

--- a/nakadi-java-client/src/test/java/nakadi/StreamProcessorTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/StreamProcessorTest.java
@@ -99,7 +99,6 @@ public class StreamProcessorTest {
     assertFalse(processor.running());
     assertTrue(processor.stopped());
 
-    assertFalse(processor.failedProcessorException().isPresent());
   }
 
   @Test
@@ -216,6 +215,9 @@ public class StreamProcessorTest {
     while (processor.running()) {
       Thread.sleep(100L);
     }
+
+    // todo: workaround for timing problem running on circleci
+    Thread.sleep(3000L);
 
     assertFalse(processor.running());
     assertTrue(processor.stopped());


### PR DESCRIPTION
This signals that the number of retries for a processor have been
met so that the processor can perform a shutdown and clean up its
underlying resources via stopStreaming.

For #284.