### PR TITLE
Lowers default batch buffer and allows setting by configuration. 

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/ExceptionSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ExceptionSupport.java
@@ -73,8 +73,7 @@ class ExceptionSupport {
       return false;
     }
 
-    logger.info(String.format("retryable_exception_consumer %s %s",
-        e.getClass(), e.getMessage()), e);
+    logger.info(String.format("retryable_exception_consumer %s %s", e.getClass(), e.getMessage()));
     return true;
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
@@ -39,6 +39,7 @@ public class StreamConfiguration {
   private long maxRetryDelay = StreamConnectionRetryFlowable.DEFAULT_MAX_DELAY_SECONDS;
   private long minRetryDelay = StreamConnectionRetryFlowable.DEFAULT_MIN_DELAY_SECONDS;
   private int maxRetryAttempts = StreamConnectionRetryFlowable.DEFAULT_MAX_ATTEMPTS;
+  private int batchBufferCount = StreamProcessor.DEFAULT_BACKPRESSURE_BUFFER_SIZE;
 
   public String eventTypeName() {
     return topic;
@@ -298,6 +299,22 @@ public class StreamConfiguration {
     return this;
   }
 
+  /**
+   * Set the number of event batches that can be buffered by the client while waiting for
+   * the StreamObserver to process them. The default is 128, and subject to change.
+   *
+   * @param eventBufferSize the number of event batches to buffer
+   * @return this
+   */
+  public StreamConfiguration batchBufferCount(int eventBufferSize) {
+    this.batchBufferCount = eventBufferSize;
+    return this;
+  }
+
+  public int batchBufferCount() {
+    return batchBufferCount;
+  }
+
   boolean isSubscriptionStream() {
     return this.subscriptionId() != null;
   }
@@ -308,7 +325,7 @@ public class StreamConfiguration {
 
   @Override public int hashCode() {
     return Objects.hash(batchLimit, streamLimit, batchFlushTimeout, streamTimeout,
-        streamKeepAliveLimit, cursors, connectTimeout, readTimeout);
+        streamKeepAliveLimit, cursors, connectTimeout, readTimeout, batchBufferCount);
   }
 
   @Override public boolean equals(Object o) {
@@ -322,6 +339,7 @@ public class StreamConfiguration {
         streamKeepAliveLimit == that.streamKeepAliveLimit &&
         connectTimeout == that.connectTimeout &&
         readTimeout == that.readTimeout &&
+        batchBufferCount == that.batchBufferCount &&
         Objects.equals(cursors, that.cursors);
   }
 
@@ -334,6 +352,7 @@ public class StreamConfiguration {
         ", cursors=" + cursors +
         ", connectTimeoutMillis=" + connectTimeout +
         ", readTimeoutMillis=" + readTimeout +
+        ", batchBufferCount=" + batchBufferCount +
         '}';
   }
 }


### PR DESCRIPTION
The stream processor can absorb event batches sent by Nakadi into a
buffer managed by the I/O layer of the processor. Observers that can't
keep up with a stream will result in the batches being buffered to a
high number. This can cause memory pressure due to the buffer not
being drained quickly enough. Also the byte size of a batch can vary
greatly based on the underlying size of each event and the number of
events requested per batch (a multi-megabyte size batch is not unheard
of).

This lowers the default batch buffer count to 128, and allows the batch
buffer count to be set via stream configuration. It's expected this will
help consumers whose observers are relatively slow compared to the rate
of events being sent and read from the network. Observers that exceed
the buffer size will drive an exception which causes a disconnect from
the server and the stream processor entering a retry cycle. The downside
is that slow consumers will tend to send more repeated events - each
disconnect causes Nakadi to reset the session, in turn that means in
flight batches/events cannot be committed via the checkpointer. They
will have to be reprocessed after a reconnection, as Nakadi will resend
the events after the client reconnects. The upside is that the consumer's
local memory pressure can be managed better.

For #256.