### PR TITLE
Stops the processor after a successful response with a stream timeout

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -368,7 +368,7 @@ public class StreamProcessor implements StreamProcessorManaged {
   private Predicate<Long> stopRepeatingPredicate() {
     return attemptCount -> {
 
-      if (streamConfiguration.streamLimit() != StreamConfiguration.DEFAULT_STREAM_TIMEOUT) {
+      if (streamConfiguration.streamLimit() != StreamConfiguration.DEFAULT_STREAM_LIMIT) {
         logger.debug(
             "op=repeater msg=will not continue to restart, request for a bounded number of events detected stream_limit={} restarts={}",
             streamConfiguration.streamLimit(), attemptCount);

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessorRequestFactory.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessorRequestFactory.java
@@ -28,6 +28,9 @@ class StreamProcessorRequestFactory {
         url);
 
     final Response response = requestStreamConnection(url, options, buildResource(sc));
+
+    streamProcessor.currentStreamResponseCode(response.statusCode());
+
     logger.info("stream_connection_open step=opened {} {}", response.hashCode(), response);
 
     return response;


### PR DESCRIPTION
This checks in the onCompleted phase if the response was 200 OK and
whether the processor was configured with a stream_timeout. If so, it's
assumed the server closed a successful response due to the stream timeout
directive sent to it, and the processor will not retry. The 200 Ok check
allows other failure modes (such as authorization) to be retried.
    
For #291.