### PR TITLE
Stops the processor after a successful response with a stream timeout.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -303,7 +303,7 @@ public class StreamProcessor implements StreamProcessorManaged {
           streamObserver.onCompleted();
           if (successfulResponseAndCustomStreamTimeout()) {
             logger.info(
-                "op=stop_processor msg=stopping_assuming_server_closed_ok_stream_due_to_stream_timeout stream_timeout={}  server_response={}",
+                "op=stop_processor_on_complete msg=stopping_assuming_server_closed_ok_stream_due_to_stream_timeout stream_timeout={}  server_response={}",
                 streamConfiguration.streamTimeoutSeconds(), this.currentStreamResponseCode);
             stopStreaming();
           }
@@ -319,6 +319,15 @@ public class StreamProcessor implements StreamProcessorManaged {
             stopStreaming();
 
           }
+
+          if (successfulResponseAndCustomStreamTimeout()) {
+            logger.info(
+                "op=stop_processor_on_cancel msg=stopping_assuming_server_closed_ok_stream_due_to_stream_timeout stream_timeout={}  server_response={}",
+                streamConfiguration.streamTimeoutSeconds(), this.currentStreamResponseCode);
+            streamObserver.onCompleted();
+            stopStreaming();
+          }
+
         })
         .timeout(halfOpenKick, halfOpenUnit)
         // retries handle issues like network failures and 409 conflicts


### PR DESCRIPTION
This checks in the onCancel phase if the response was 200 OK and
whether the processor was configured with a stream_timeout. If so, it's
assumed the server closed a successful response due to the stream timeout
directive sent to it, and the processor will not retry. The 200 Ok check
allows other failure modes (such as authorization) to be retried.

For #291.