### PR TITLE
Improve stream consumption handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ target/
 */**/out
 
 */**/*z*.pem
+
+logback-test.xml

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -354,7 +354,6 @@ public class StreamProcessor implements StreamProcessorManaged {
       final BufferedReader br = new BufferedReader(response.responseBody().asReader());
       return Flowable.fromIterable(br.lines()::iterator)
           .doOnError(throwable -> ResponseSupport.closeQuietly(response))
-          .onBackpressureBuffer(onBackPressureBufferSize())
           .map(r -> lineToStreamBatchRecord(r, literal, response, sc));
     };
   }

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -415,13 +415,13 @@ public class StreamProcessor implements StreamProcessorManaged {
   private <T> StreamBatchRecord<T> lineToStreamBatchRecord(String line,
       TypeLiteral<T> typeLiteral, Response response, StreamConfiguration sc) {
 
-    logger.debug("op=line_to_batch line={}, res={}", line, response);
-
     if (sc.isSubscriptionStream()) {
       String sessionId = response.headers().get(X_NAKADI_STREAM_ID).get(0);
+      logger.debug("op=line_to_batch x_nakadi_stream_id={} line={}, response={}", sessionId, line, response);
       return jsonBatchSupport.lineToSubscriptionStreamBatchRecord(
           line, typeLiteral.type(), streamOffsetObserver(), sessionId, sc.subscriptionId());
     } else {
+      logger.debug("op=line_to_batch line={}, response={}", line, response);
       return jsonBatchSupport.lineToEventStreamBatchRecord(
           line, typeLiteral.type(), streamOffsetObserver());
     }


### PR DESCRIPTION
Removes custom buffering from stream processor.

Previously when the library usd RxJava 1, buffering was added to
control backpressure between the http and observer layers in the
case when the observer couldn't keep up. Backpressure's been
changed in RxJava2 with the Flowable type the client uses. The
Flowable type handles backpressure more gracefully and removing
the custom settings from the RxJava 1 days seems to greatly
improve handling of events off the wire, eg streams
being consumed more or less indefinitely without retry and
disconnects.