### PR TITLE
Cleanup: use logical 'and' for booleans

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -159,7 +159,7 @@ public class StreamProcessor implements StreamProcessorManaged {
    * @return true if running, false if not.
    */
   public boolean running() {
-    return !stopping() && !stopped() & started();
+    return !stopping() && !stopped() && started();
   }
 
   /**


### PR DESCRIPTION
Not a bug, bus still looks suspicious of first sight.

This is more of a comment. I see that `StreamProcessor#stopping()` checks both `this.stopped` and `this.stopping` while in both cases when stopping is used both  `StreamProcessor#stopping()` and `StreamProcessor#stopped()` are invoked:
* `!stopping() && !stopped() && started()`  in `StreamProcessor#running()`
* `stopped() || stopping()` in in `StreamProcessor#start()`

So this looks redundant. That is `StreamProcessor#stopping()` could check only `this.stopping` without logic change, or, alternatively, leave only `StreamProcessor#stopped` that would check both.

Another comment is that using 3 state variables `stopping`, `stopped`, and `running` begs for inconsistencies (e.g. running == true and stopped == true), I would implemented it a single state var and enum, say, [INIT, STARTED, STOPPING, STOPPED].
