### PR TITLE
Makes the SubscriptionEventTypeStatsCollection constructor public.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionEventTypeStatsCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionEventTypeStatsCollection.java
@@ -12,6 +12,13 @@ public class SubscriptionEventTypeStatsCollection
 
   private final SubscriptionResourceReal subscriptionResource;
 
+  public SubscriptionEventTypeStatsCollection(List<SubscriptionEventTypeStats> items,
+      List<ResourceLink> links, NakadiClient client,
+      SubscriptionResourceReal subscriptionResource) {
+    super(items, links, client);
+    this.subscriptionResource = subscriptionResource;
+  }
+
   SubscriptionEventTypeStatsCollection(List<SubscriptionEventTypeStats> items,
       List<ResourceLink> links, SubscriptionResourceReal subscriptionResource, NakadiClient client) {
     super(items, links, client);

--- a/nakadi-java-client/src/test/java/nakadi/test/SubscriptionEventTypeStatsCollectionVisibilityTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/test/SubscriptionEventTypeStatsCollectionVisibilityTest.java
@@ -1,0 +1,21 @@
+package nakadi.test;
+
+import com.google.common.collect.Lists;
+import nakadi.SubscriptionEventTypeStatsCollection;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SubscriptionEventTypeStatsCollectionVisibilityTest {
+
+  @Test
+  public void isPublic() {
+
+    assertNotNull(new SubscriptionEventTypeStatsCollection(
+        null,
+        Lists.newArrayList(),
+        null,
+        null));
+  }
+
+}


### PR DESCRIPTION
This allows for easier testing by end users.