### PR TITLE
Allows a consumer to see the checkpoint response result from the server.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/MetricCollector.java
+++ b/nakadi-java-client/src/main/java/nakadi/MetricCollector.java
@@ -89,6 +89,17 @@ public interface MetricCollector {
     sessionCheckpointNetworkException("nakadi.java.client.event.sessionCheckpointNetworkException"),
 
     /**
+     * Each time the server returns 200 for a stale checkpoint request.
+     */
+    sessionCheckpointOkIndicatedStaleCursor(
+        "nakadi.java.client.event.sessionCheckpointOkIndicatedStaleCursor"),
+
+    /**
+     * Each time the server returns 204 for an accepted checkpoint request.
+     */
+    sessionCheckpointAcceptedCursor("nakadi.java.client.event.sessionCheckpointAcceptedCursor"),
+
+    /**
      * Each time an unknown error response is seen.
      */
     httpUnknown("nakadi.java.client.http.error"),

--- a/nakadi-java-client/src/test/resources/cursor-commit-result-1.json
+++ b/nakadi-java-client/src/test/resources/cursor-commit-result-1.json
@@ -1,0 +1,13 @@
+{
+  "items": [
+    {
+      "cursor": {
+        "event_type": "woo",
+        "cursor_token": "0-cursor_token",
+        "partition": "0",
+        "offset": "4"
+      },
+      "result": "outdated"
+    }
+  ]
+}


### PR DESCRIPTION
This provides a consumer hook to view the CursorCommitResultCollection result
from the server, along with the initiating StreamCursorContext. If the
CursorCommitResultCollection.items() collection is empty (a 200 Ok) from the
server it means the server moved the cursor forward. If the
CursorCommitResultCollection.items() collection is not empty (a 204 No-Content)
it means the server ignored a stale cursor. A stale cursor is strongly
indicative of a local processing problem.

This change also adds metrics for the two result forms to the MetricCollector
object and calls the collector based on the server result.