### PR TITLE
Retry cleanups

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
+++ b/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
@@ -115,7 +115,7 @@ public class ExponentialRetry implements RetryPolicy {
       NakadiException.throwNonNull(unit, "Please provide a TimeUnit");
       this.initialInterval = unit.toMillis(initialInterval);
       if (this.initialInterval < INITIAL_INTERVAL_MIN_AS_MILLIS) {
-        NakadiException.throwNonNull(null, "Please provide an initial value of at least "
+        throw new IllegalArgumentException("Please provide an initial value of at least "
             + INITIAL_INTERVAL_MIN_AS_MILLIS
             + " millis");
       }
@@ -126,7 +126,7 @@ public class ExponentialRetry implements RetryPolicy {
       NakadiException.throwNonNull(unit, "Please provide a TimeUnit");
       this.maxInterval = unit.toMillis(maxInterval);
       if (this.maxInterval < MAX_INTERVAL_MIN_AS_MILLIS) {
-        NakadiException.throwNonNull(null, "Please provide a max interval value of at least "
+        throw new IllegalArgumentException("Please provide a max interval value of at least "
             + MAX_INTERVAL_MIN_AS_MILLIS
             + " millis");
       }

--- a/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
+++ b/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
@@ -18,7 +18,6 @@ public class ExponentialRetry implements RetryPolicy {
   long workingAttempts = 1;
   long maxTime;
   long workingTime = 0L;
-  TimeUnit unit;
   private long workingInterval;
   private volatile long startTime = 0L;
   private float percentOfMaxIntervalForJitter;
@@ -28,7 +27,6 @@ public class ExponentialRetry implements RetryPolicy {
     this.maxInterval = builder.maxInterval;
     this.workingInterval = initialInterval;
     this.maxAttempts = builder.maxAttempts;
-    this.unit = builder.unit;
     this.maxTime = builder.maxTime;
     this.percentOfMaxIntervalForJitter = builder.percentOfMaxIntervalForJitter;
   }
@@ -61,11 +59,11 @@ public class ExponentialRetry implements RetryPolicy {
       return STOP;
     }
 
-    workingInterval = unit.toMillis(workingInterval) * (workingAttempts * workingAttempts);
+    workingInterval = workingInterval * (workingAttempts * workingAttempts);
     workingAttempts++;
 
     if (workingInterval <= 0) {
-      workingInterval = unit.toMillis(maxInterval);
+      workingInterval = maxInterval;
     }
 
     if (initialInterval != workingInterval) {
@@ -100,13 +98,10 @@ public class ExponentialRetry implements RetryPolicy {
         ", maxInterval=" + maxInterval +
         ", maxAttempts=" + maxAttempts +
         ", workingAttempts=" + workingAttempts +
-        ", unit=" + unit +
         '}';
   }
 
   public static class Builder {
-
-    private final TimeUnit unit = TimeUnit.MILLISECONDS;
     public float percentOfMaxIntervalForJitter = PERCENT_OF_MAX_INTERVAL_AS_JITTER;
     private long initialInterval = DEFAULT_INITIAL_INTERVAL_MILLIS;
     private long maxInterval = DEFAULT_MAX_INTERVAL_MILLIS;

--- a/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
+++ b/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
@@ -17,7 +17,7 @@ public class ExponentialRetry implements RetryPolicy {
   int maxAttempts;
   long workingAttempts = 1;
   long maxTime;
-  long workingTime = 0L;
+  long lastBackoff = 0L;
   private long workingInterval;
   private volatile long startTime = 0L;
   private float percentOfMaxIntervalForJitter;
@@ -44,7 +44,7 @@ public class ExponentialRetry implements RetryPolicy {
   }
 
   public boolean isFinished() {
-    return workingAttempts >= maxAttempts || workingTime >= maxTime;
+    return workingAttempts >= maxAttempts || (lastBackoff - startTime) >= maxTime;
   }
 
   public long nextBackoffMillis() {
@@ -52,11 +52,10 @@ public class ExponentialRetry implements RetryPolicy {
   }
 
   long nextBackOffMillis(long nowMillis) {
-    if (this.startTime == 0L) {
-      this.startTime = nowMillis;
-    } else {
-      workingTime += (nowMillis - this.startTime);
+    if (startTime == 0L) {
+      startTime = nowMillis;
     }
+    lastBackoff = nowMillis;
 
     if (isFinished()) {
       return STOP;

--- a/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
+++ b/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
@@ -48,11 +48,14 @@ public class ExponentialRetry implements RetryPolicy {
   }
 
   public long nextBackoffMillis() {
+    return nextBackOffMillis(System.currentTimeMillis());
+  }
 
-    if (startTime == 0L) {
-      startTime = System.currentTimeMillis();
+  long nextBackOffMillis(long nowMillis) {
+    if (this.startTime == 0L) {
+      this.startTime = nowMillis;
     } else {
-      workingTime += (System.currentTimeMillis() - startTime);
+      workingTime += (nowMillis - this.startTime);
     }
 
     if (isFinished()) {

--- a/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
+++ b/nakadi-java-client/src/main/java/nakadi/ExponentialRetry.java
@@ -17,7 +17,7 @@ public class ExponentialRetry implements RetryPolicy {
   int maxAttempts;
   long workingAttempts = 1;
   long maxTime;
-  long lastBackoff = 0L;
+  private long lastBackoff = 0L;
   private long workingInterval;
   private volatile long startTime = 0L;
   private float percentOfMaxIntervalForJitter;
@@ -43,8 +43,12 @@ public class ExponentialRetry implements RetryPolicy {
     return maxInterval;
   }
 
+  long workingTime() {
+    return lastBackoff - startTime;
+  }
+
   public boolean isFinished() {
-    return workingAttempts >= maxAttempts || (lastBackoff - startTime) >= maxTime;
+    return workingAttempts >= maxAttempts || workingTime() >= maxTime;
   }
 
   public long nextBackoffMillis() {

--- a/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
@@ -31,7 +31,7 @@ public class ExponentialRetryTest {
   }
 
   private void validateTimeoutState(ExponentialRetry exponentialRetry) {
-    assertTrue(exponentialRetry.lastBackoff >= exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.workingTime() >= exponentialRetry.maxTime);
     assertTrue(exponentialRetry.workingAttempts < exponentialRetry.maxAttempts);
   }
 
@@ -74,7 +74,7 @@ public class ExponentialRetryTest {
   }
 
   private void validateRetriesExceededState(ExponentialRetry exponentialRetry) {
-    assertTrue(exponentialRetry.lastBackoff < exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.workingTime() < exponentialRetry.maxTime);
     assertTrue(exponentialRetry.workingAttempts >= exponentialRetry.maxAttempts);
   }
 

--- a/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
@@ -57,6 +57,21 @@ public class ExponentialRetryTest {
     validateRetriesExceededState(exponentialRetry);
   }
 
+  @Test
+  public void workingTimeCalculation() {
+    ExponentialRetry exponentialRetry = ExponentialRetry.newBuilder()
+            .maxAttempts(1000)
+            .maxInterval(100, TimeUnit.MILLISECONDS)
+            .maxTime(110, TimeUnit.MILLISECONDS)
+            .build();
+    exponentialRetry.nextBackOffMillis(1);
+    exponentialRetry.nextBackOffMillis(100);
+    exponentialRetry.nextBackOffMillis(101);
+    assertFalse(exponentialRetry.isFinished());
+    exponentialRetry.nextBackOffMillis(110);
+    assertTrue(exponentialRetry.isFinished());
+  }
+
   private void validateRetriesExceededState(ExponentialRetry exponentialRetry) {
     assertTrue(exponentialRetry.workingTime < exponentialRetry.maxTime);
     assertTrue(exponentialRetry.workingAttempts >= exponentialRetry.maxAttempts);

--- a/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
@@ -64,7 +64,9 @@ public class ExponentialRetryTest {
             .maxTime(110, TimeUnit.MILLISECONDS)
             .build();
     exponentialRetry.nextBackOffMillis(1);
+    assertFalse(exponentialRetry.isFinished());
     exponentialRetry.nextBackOffMillis(100);
+    assertFalse(exponentialRetry.isFinished());
     exponentialRetry.nextBackOffMillis(101);
     assertFalse(exponentialRetry.isFinished());
     exponentialRetry.nextBackOffMillis(111);

--- a/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
@@ -31,7 +31,7 @@ public class ExponentialRetryTest {
   }
 
   private void validateTimeoutState(ExponentialRetry exponentialRetry) {
-    assertTrue(exponentialRetry.workingTime >= exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.lastBackoff >= exponentialRetry.maxTime);
     assertTrue(exponentialRetry.workingAttempts < exponentialRetry.maxAttempts);
   }
 
@@ -60,7 +60,6 @@ public class ExponentialRetryTest {
   @Test
   public void workingTimeCalculation() {
     ExponentialRetry exponentialRetry = ExponentialRetry.newBuilder()
-            .maxAttempts(1000)
             .maxInterval(100, TimeUnit.MILLISECONDS)
             .maxTime(110, TimeUnit.MILLISECONDS)
             .build();
@@ -68,12 +67,12 @@ public class ExponentialRetryTest {
     exponentialRetry.nextBackOffMillis(100);
     exponentialRetry.nextBackOffMillis(101);
     assertFalse(exponentialRetry.isFinished());
-    exponentialRetry.nextBackOffMillis(110);
+    exponentialRetry.nextBackOffMillis(111);
     assertTrue(exponentialRetry.isFinished());
   }
 
   private void validateRetriesExceededState(ExponentialRetry exponentialRetry) {
-    assertTrue(exponentialRetry.workingTime < exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.lastBackoff < exponentialRetry.maxTime);
     assertTrue(exponentialRetry.workingAttempts >= exponentialRetry.maxAttempts);
   }
 


### PR DESCRIPTION
* Correct working time calculation
* Default to milliseconds in retry object internally, remove TimeUnit field.
* Extract duplication code in test
* Streamline retry builder error checking