### PR TITLE
Stops creating default values for EventMetadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,10 @@ You can send one or more events to the server:
 ```java
 EventResource resource = client.resources().events();
  
-// nb: EventMetadata sets defaults for eid, occurred at and flow id fields
-EventMetadata em = new EventMetadata();
+// nb: EventMetadata.newPreparedEventMetadata sets defaults for eid, occurred at and flow id fields
+EventMetadata em = EventMetadata.newPreparedEventMetadata();
+
+EventMetadata em1 = new EventMetadata();
   .eid(UUID.randomUUID().toString())
   .occurredAt(OffsetDateTime.now())
   .flowId("decafbad");
@@ -389,13 +391,13 @@ Response response = resource.send("priority-requisitions", dce);
 // send a batch of two events
  
 DataChangeEvent<PriorityRequisition> dce1 = new DataChangeEvent<PriorityRequisition>()
-  .metadata(new EventMetadata())
+  .metadata(EventMetadata.newPreparedEventMetadata())
   .op(DataChangeEvent.Op.C)
   .dataType("priority-requisitions")
   .data(new PriorityRequisition("23"));
  
 DataChangeEvent<PriorityRequisition> dce2 = new DataChangeEvent<PriorityRequisition>()
-  .metadata(new EventMetadata())
+  .metadata(EventMetadata.newPreparedEventMetadata())
   .op(DataChangeEvent.Op.C)
   .dataType("priority-requisitions")
   .data(new PriorityRequisition("24"));

--- a/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
@@ -19,10 +19,47 @@ public class EventMetadata {
   private String partition;
   private String version;
 
+  /**
+   * Create a new EventMetadata prepared with values for eid, occurred at, and flow id.
+   * @return an EventMetadata
+   */
+  public static EventMetadata newPreparedEventMetadata() {
+    return new EventMetadata().withEid().withFlowId().withOccurredAt();
+  }
+
+  /**
+   * Create a new EventMetadata.
+   * <p>
+   *   The object is <b>not</b> prepared with any values, such eid, occurred at, and flow id. To
+   *   create an EventMetadata with prepared values use {@link #newPreparedEventMetadata()}
+   * </p>
+   * @return an EventMetadata
+   */
   public EventMetadata() {
-    this.flowId = ResourceSupport.nextFlowId();
-    this.eid = ResourceSupport.nextEid();
-    this.occurredAt = OffsetDateTime.now();
+  }
+
+  /**
+   * Set an event identifier on this metadata.
+   * @return this
+   */
+  public EventMetadata withEid() {
+    return newEid();
+  }
+
+  /**
+   * Set an occurred at time on this metadata.
+   * @return this
+   */
+  public EventMetadata withOccurredAt() {
+    return newOccurredAt();
+  }
+
+  /**
+   * Set a flow id on this metadata.
+   * @return this
+   */
+  public EventMetadata withFlowId() {
+    return newFlowId();
   }
 
   /**

--- a/nakadi-java-client/src/test/java/nakadi/EventMetadataTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventMetadataTest.java
@@ -1,0 +1,29 @@
+package nakadi;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EventMetadataTest {
+
+  @Test
+  public void testNewPreparedEventMetadata() {
+    final EventMetadata eventMetadata = EventMetadata.newPreparedEventMetadata();
+    assertNotNull(eventMetadata.eid());
+    assertNotNull(eventMetadata.occurredAt());
+    assertNotNull(eventMetadata.flowId());
+  }
+
+  @Test
+  public void testNewEventMetadata() {
+    /*
+     https://github.com/dehora/nakadi-java/issues/321
+     default values for these three, especially eid had a performance overhead
+      */
+    final EventMetadata eventMetadata = new EventMetadata();
+    assertNull(eventMetadata.eid());
+    assertNull(eventMetadata.occurredAt());
+    assertNull(eventMetadata.flowId());
+  }
+
+}

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
@@ -241,7 +241,7 @@ public class EventResourceRealTest {
 
     BusinessEventMapped<BusinessPayload> event =
         new BusinessEventMapped<BusinessPayload>()
-            .metadata(new EventMetadata())
+            .metadata(EventMetadata.newPreparedEventMetadata())
             .data(bp);
 
     try {
@@ -420,7 +420,7 @@ public class EventResourceRealTest {
 
     BusinessEventMapped<Map<String, Object>> be = new BusinessEventMapped<>();
     EventMetadata em = new EventMetadata();
-    em.eid("eid1");
+    em.eid("eid1").withFlowId().withOccurredAt();
     Map<String, Object> uemap = Maps.newHashMap();
     uemap.put("a", 1);
     uemap.put("b", 22.0001);


### PR DESCRIPTION
The previous constructor had a performance overhead in creating
default values (especially for eid, which used UUID.randomUUID).
A prepared EventMetadata can be created using newPreparedEventMetadata
instead.

For #321.