### PR TITLE
0.8.5.1 (patch release from 0.8.5)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ### Changes
 
+### 0.8.5.1
+
+2018/04/12: This is patch release forked from 0.8.5
+
+- Suppresses logging of some unhandled exceptions from StreamProcessor.
+
 ### 0.8.5
 
 - Adds support for cursor reset API.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.8.5
+version=0.8.5.1
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/nakadi-java-client/src/main/java/nakadi/Version.java
+++ b/nakadi-java-client/src/main/java/nakadi/Version.java
@@ -2,5 +2,5 @@ package nakadi;
 
 public class Version {
 
-  public static final String VERSION = "0.8.5";
+  public static final String VERSION = "0.8.5.1";
 }


### PR DESCRIPTION
### 0.8.5.1

2018/04/12: This is patch release forked from 0.8.5

- Suppresses logging of some unhandled exceptions from StreamProcessor.