### PR TITLE
Support log compaction

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
@@ -18,6 +18,7 @@ public class EventMetadata {
   private String flowId;
   private String partition;
   private String version;
+  private String partitionCompactionKey;
 
   /**
    * Create a new EventMetadata prepared with values for eid, occurred at, and flow id.
@@ -82,6 +83,24 @@ public class EventMetadata {
 
   EventMetadata newEid() {
     this.eid = ResourceSupport.nextEid();
+    return this;
+  }
+
+  /**
+   * @return the event partition compaction key
+   */
+  public String partitionCompactionKey() {
+    return this.partitionCompactionKey;
+  }
+
+  /**
+   * Set the event partition compaction key
+   *
+   * @param partitionCompactionKey is the string used for compaction of events
+   * @return this
+   */
+  public EventMetadata partitionCompactionKey(String partitionCompactionKey) {
+    this.partitionCompactionKey = partitionCompactionKey;
     return this;
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/EventType.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventType.java
@@ -16,6 +16,8 @@ public class EventType {
   public static final String ENRICHMENT_METADATA = "metadata_enrichment";
   public static final String PARTITION_RANDOM = "random";
   public static final String PARTITION_HASH = "hash";
+  public static final String DELETE = "delete";
+  public static final String COMPACT = "compact";
   private static final List<String> SENTINEL_EMPTY_SCOPES =
       Collections.unmodifiableList(Lists.newArrayList());
   private final List<String> enrichmentStrategies = new ArrayList<>();
@@ -29,6 +31,7 @@ public class EventType {
   private EventTypeOptions options;
   private String compatibilityMode;
   private EventTypeAuthorization authorization;
+  private String cleanupPolicy;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;
 
@@ -316,6 +319,24 @@ public class EventType {
    */
   public EventType authorization(EventTypeAuthorization authorization) {
     this.authorization = authorization;
+    return this;
+  }
+
+  /**
+   * @return the cleanup policy for this event type
+   */
+  public String cleanupPolicy() {
+    return this.cleanupPolicy;
+  }
+
+  /**
+   * Set the cleanup policy for this event type
+   *
+   * @param cleanupPolicy for this event type
+   * @return this
+   */
+  public EventType cleanupPolicy(String cleanupPolicy) {
+    this.cleanupPolicy = cleanupPolicy;
     return this;
   }
 

--- a/nakadi-java-client/src/test/java/nakadi/EventMetadataTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventMetadataTest.java
@@ -24,6 +24,7 @@ public class EventMetadataTest {
     assertNull(eventMetadata.eid());
     assertNull(eventMetadata.occurredAt());
     assertNull(eventMetadata.flowId());
+    assertNull(eventMetadata.partitionCompactionKey());
   }
 
 }

--- a/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
@@ -89,6 +89,7 @@ public class EventTypeTest {
     assertEquals(EventType.Category.business, eventType.category());
     assertEquals(Lists.newArrayList("metadata_enrichment"), eventType.enrichmentStrategies());
     assertEquals("random", eventType.partitionStrategy());
+    assertEquals("delete", eventType.cleanupPolicy());
     assertNotNull(eventType.partitionKeyFields());
     assertNotNull(eventType.enrichmentStrategies());
     assertNull(eventType.eventTypeStatistics());

--- a/nakadi-java-client/src/test/java/nakadi/JsonBatchSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/JsonBatchSupportTest.java
@@ -111,6 +111,7 @@ public class JsonBatchSupportTest {
     assertEquals("0", metadata.partition());
     assertEquals("2016-10-26T18:12:20.712Z", metadata.receivedAt().toString());
     assertEquals("Nt0oU70k3UCNp2NKugrIF0QU", metadata.flowId());
+    assertEquals("a-compaction-key", metadata.partitionCompactionKey());
 
     UndefinedPayload data = event.data();
     assertEquals("1", data.id);

--- a/nakadi-java-client/src/test/resources/business-event-batch-1.json
+++ b/nakadi-java-client/src/test/resources/business-event-batch-1.json
@@ -11,7 +11,8 @@
         "event_type": "et-1",
         "partition": "0",
         "received_at": "2016-10-26T18:12:20.712Z",
-        "flow_id": "Nt0oU70k3UCNp2NKugrIF0QU"
+        "flow_id": "Nt0oU70k3UCNp2NKugrIF0QU",
+        "partition_compaction_key": "a-compaction-key"
       },
       "id": "1",
       "foo": "2",

--- a/nakadi-java-client/src/test/resources/event-type-1.json
+++ b/nakadi-java-client/src/test/resources/event-type-1.json
@@ -10,6 +10,7 @@
     "type": "json_schema",
     "schema": "{ \"properties\": { \"order_number\": { \"type\": \"string\" } } }"
   },
+  "cleanup_policy": "delete",
   "authorization": {
     "admins": [{"data_type": "*", "value": "a"}],
     "readers": [{"data_type": "*", "value": "r"}],


### PR DESCRIPTION
Since Nakadi version 2.8.1 event types have now support for log
compaction. See the [API](https://nakadi.io/manual.html#definition_EventType*cleanup_policy) for more details.

Log compacted event types must specify an option `compact` cleanup
policy during creation. All events from log compacted event types must
contain `metadata.partition_compaction_key` in order for Nakadi to
perform compaction.

Events sent to event types that are **not** log compacted should **not** have `metadata.partition_compaction_key` in their metadata. That would cause rejection of events.

I understood that gson omits null values by default but I couldn't find tests for marshalling objects into bytes.