### PR TITLE
0.9.17 backport: Strips trailing '/' from arg supplied to UriBuilder.builder.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/UriBuilder.java
+++ b/nakadi-java-client/src/main/java/nakadi/UriBuilder.java
@@ -52,7 +52,15 @@ class UriBuilder {
   }
 
   public static UriBuilder builder(String uri) {
-    return new UriBuilder(uri);
+    return new UriBuilder(rmTrailingSlash(uri));
+  }
+
+  private static String rmTrailingSlash(String uri) {
+    if (uri.endsWith("/")) {
+      return uri.substring(0, uri.length() - 1);
+    }
+
+    return uri;
   }
 
   public static UriBuilder builder(URI uri) {

--- a/nakadi-java-client/src/test/java/nakadi/UriBuilderTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/UriBuilderTest.java
@@ -7,6 +7,15 @@ import static org.junit.Assert.assertEquals;
 public class UriBuilderTest {
 
   @Test
+  public void buildPathBaseURIWithTrailingSlash() {
+    assertEquals("http://example.org/event-types/one",
+        UriBuilder.builder("http://example.org/")
+            .path("event-types")
+            .path("one")
+            .buildString());
+  }
+
+  @Test
   public void buildPath() {
     assertEquals("http://example.org/event-types/one",
         UriBuilder.builder("http://example.org")


### PR DESCRIPTION
This checks the URI string supplied to UriBuilder.builder
and if a trailing slash is found it's removed. It allows
configurations to not worry about whether the Nakadi base
URI has a trailing slash

For #330.