### PR TITLE
0.9.17 backport: Strips trailing '/' from arg supplied to UriBuilder.builder.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### Changes
 
+### 0.8.5.2
+
+- Backport from [0.11.0](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.11.0). Strips trailing '/' from arg supplied to UriBuilder.builder. [#330](https://github.com/dehora/nakadi-java/pull/330)
+
 ### 0.8.5.1
 
 2018/04/12: This is patch release forked from 0.8.5

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 - Build: [![CircleCI](https://circleci.com/gh/zalando-incubator/nakadi-java.svg?style=svg)](https://circleci.com/gh/zalando-incubator/nakadi-java)
 - Release Download: [ ![Download](https://api.bintray.com/packages/dehora/maven/nakadi-java-client/images/download.svg) ](https://bintray.com/dehora/maven/nakadi-java-client/_latestVersion)
-- Source Release: [0.8.5](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.8.5)
+- Source Release: [0.8.5.2](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.8.5.2)
 - Contact: [maintainers](https://github.com/zalando-incubator/nakadi-java/blob/master/MAINTAINERS)
 
 
@@ -101,7 +101,7 @@ The client's had some basic testing to verify it can handle things like
 consumer stream connection/network failures and retries. It should not be 
 deemed robust yet, but it is a goal to produce a well-behaved production 
 level client especially for producing and consuming events for 1.0.0. The 
-releases from 0.8.5 and onwards seem fairly sane.
+releases from 0.8.5.2 and onwards seem fairly sane.
 
 See also:
 
@@ -671,7 +671,7 @@ and add the project declaration to `pom.xml`:
 <dependency>
   <groupId>net.dehora.nakadi</groupId>
   <artifactId>nakadi-java-client</artifactId>
-  <version>0.8.5</version>
+  <version>0.8.5.2</version>
 </dependency>
 ```
 ### Gradle
@@ -688,7 +688,7 @@ and add the project to the `dependencies` block in `build.gradle`:
 
 ```groovy
 dependencies {
-  compile 'net.dehora.nakadi:nakadi-java-client:0.8.5'
+  compile 'net.dehora.nakadi:nakadi-java-client:0.8.5.2'
 }  
 ```
 
@@ -703,7 +703,7 @@ resolvers += "jcenter" at "http://jcenter.bintray.com"
 and add the project to `libraryDependencies` in `build.sbt`:
 
 ```scala
-libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.8.5"
+libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.8.5.2"
 ```
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.8.5.1
+version=0.8.5.2
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/nakadi-java-client/src/main/java/nakadi/UriBuilder.java
+++ b/nakadi-java-client/src/main/java/nakadi/UriBuilder.java
@@ -52,7 +52,15 @@ class UriBuilder {
   }
 
   public static UriBuilder builder(String uri) {
-    return new UriBuilder(uri);
+    return new UriBuilder(rmTrailingSlash(uri));
+  }
+
+  private static String rmTrailingSlash(String uri) {
+    if (uri.endsWith("/")) {
+      return uri.substring(0, uri.length() - 1);
+    }
+
+    return uri;
   }
 
   public static UriBuilder builder(URI uri) {

--- a/nakadi-java-client/src/main/java/nakadi/Version.java
+++ b/nakadi-java-client/src/main/java/nakadi/Version.java
@@ -2,5 +2,5 @@ package nakadi;
 
 public class Version {
 
-  public static final String VERSION = "0.8.5.1";
+  public static final String VERSION = "0.8.5.2";
 }

--- a/nakadi-java-client/src/test/java/nakadi/UriBuilderTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/UriBuilderTest.java
@@ -7,6 +7,15 @@ import static org.junit.Assert.assertEquals;
 public class UriBuilderTest {
 
   @Test
+  public void buildPathBaseURIWithTrailingSlash() {
+    assertEquals("http://example.org/event-types/one",
+        UriBuilder.builder("http://example.org/")
+            .path("event-types")
+            .path("one")
+            .buildString());
+  }
+
+  @Test
   public void buildPath() {
     assertEquals("http://example.org/event-types/one",
         UriBuilder.builder("http://example.org")


### PR DESCRIPTION
Strips trailing '/' from arg supplied to UriBuilder.builder.

This checks the URI string supplied to UriBuilder.builder 
and if a trailing slash is found it's removed. It allows 
configurations to not worry about whether the Nakadi base 
URI has a trailing slash

For #330.