### PR TITLE
Fix instructions for bintray jcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ dependencies {
 Add jcenter to `resolvers` in `build.sbt`:
 
 ```scala
-resolvers += "jcenter" at "http://jcenter.bintray.com"
+resolvers += Resolver.jcenterRepo
 ```
 
 and add the project to `libraryDependencies` in `build.sbt`:


### PR DESCRIPTION
Using bintray jcenter over HTTP is now unsupported: https://jfrog.com/jcenter-http/

So the instructions for adding the lib for SBT did not work anymore: the library doesn't resolve correctly with these settings.
This fixes it by using SBT's [predefined resolver definition for JCenter Bintray](https://www.scala-sbt.org/1.x/docs/Resolvers.html#Predefined+resolvers), which uses HTTPS.

Tested by following these instructions for using lib in my own Scala project, this resolves fine with the change.