### PR TITLE
Add 'audience' field to EventType model

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventType.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventType.java
@@ -32,6 +32,7 @@ public class EventType {
   private String compatibilityMode;
   private EventTypeAuthorization authorization;
   private String cleanupPolicy;
+  private String audience;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;
 
@@ -340,6 +341,24 @@ public class EventType {
     return this;
   }
 
+  /**
+   * @return the audience for this event type
+   */
+  public String audience() {
+    return this.audience;
+  }
+
+  /**
+   * Set the audience for this event type
+   *
+   * @param audience for this event type
+   * @return this
+   */
+  public EventType audience(String audience) {
+    this.audience = audience;
+    return this;
+  }
+
   @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
@@ -355,6 +374,7 @@ public class EventType {
         Objects.equals(options, eventType.options) &&
         Objects.equals(compatibilityMode, eventType.compatibilityMode) &&
         Objects.equals(authorization, eventType.authorization) &&
+        Objects.equals(audience, eventType.audience) &&
         Objects.equals(createdAt, eventType.createdAt) &&
         Objects.equals(updatedAt, eventType.updatedAt);
   }
@@ -371,6 +391,7 @@ public class EventType {
         ", options=" + options +
         ", compatibilityMode='" + compatibilityMode + '\'' +
         ", authorization=" + authorization +
+        ", audience=" + audience +
         ", createdAt=" + createdAt +
         ", updatedAt=" + updatedAt +
         '}';

--- a/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventTypeTest.java
@@ -95,6 +95,7 @@ public class EventTypeTest {
     assertNull(eventType.eventTypeStatistics());
     assertNull(eventType.options());
     assertEquals("delete", eventType.cleanupPolicy());
+    assertEquals("component-internal", eventType.audience());
     final EventTypeAuthorization authorization = eventType.authorization();
     assertNotNull(authorization);
     assertNotNull(authorization.admins());
@@ -134,6 +135,7 @@ public class EventTypeTest {
     assertNull(eventType2.eventTypeStatistics());
     assertNull(eventType2.options());
     assertEquals("delete", eventType2.cleanupPolicy());
+    assertEquals("component-internal", eventType2.audience());
     final EventTypeAuthorization authorization = eventType2.authorization();
     assertNotNull(authorization);
     assertNotNull(authorization.admins());

--- a/nakadi-java-client/src/test/resources/event-type-1.json
+++ b/nakadi-java-client/src/test/resources/event-type-1.json
@@ -15,5 +15,6 @@
     "admins": [{"data_type": "*", "value": "a"}],
     "readers": [{"data_type": "*", "value": "r"}],
     "writers": [{"data_type": "*", "value": "w"}]
-  }
+  },
+  "audience": "component-internal"
 }


### PR DESCRIPTION
Fixes #348 by adding new field: `EventType.audience`

This solves the issue that clients cannot update event types having this field set because it does not get marshalled and Nakadi responds with an error, as recently Nakadi API began disallow setting `audience` to `null` once it has been specified.

Updated the unmarshalling unit tests.