### PR TITLE
Add commit_timeout parameter to stream configuration

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
@@ -19,6 +19,7 @@ public class StreamConfiguration {
   static final int DEFAULT_STREAM_LIMIT = 0;
   static final int DEFAULT_BATCH_FLUSH_TIMEOUT = 30;
   static final int DEFAULT_STREAM_TIMEOUT = 0;
+  static final int DEFAULT_COMMIT_TIMEOUT = 60;
   static final int DEFAULT_STREAM_KEEPALIVE_COUNT = 0;
   static final int DEFAULT_MAX_UNCOMMITTED_EVENTS = 10;
   private final Map<String, String> requestHeaders = new HashMap<>();
@@ -27,6 +28,7 @@ public class StreamConfiguration {
   private int streamLimit = DEFAULT_STREAM_LIMIT;
   private long batchFlushTimeout = DEFAULT_BATCH_FLUSH_TIMEOUT;
   private long streamTimeout = DEFAULT_STREAM_TIMEOUT;
+  private long commitTimeout = DEFAULT_COMMIT_TIMEOUT;
   private int streamKeepAliveLimit = DEFAULT_STREAM_KEEPALIVE_COUNT;
   private List<Cursor> cursors;
   private String topic;
@@ -166,6 +168,23 @@ public class StreamConfiguration {
    */
   public StreamConfiguration streamTimeout(long streamTimeout, TimeUnit unit) {
     this.streamTimeout = unit.toSeconds(streamTimeout);
+    return this;
+  }
+
+  public long commitTimeoutSeconds() {
+    return commitTimeout;
+  }
+
+  /**
+   * Set the maximum time (in seconds) that nakadi will be waiting for commit after sending a
+   * batch to a client. In case if commit does not come within this timeout, nakadi will
+   * initialize stream termination, no new data will be sent. Partitions from this stream
+   * will be assigned to other streams.
+   *
+   * Setting commit_timeout to 0 is equal to setting it to the maximum allowed value - 60.
+   */
+  public StreamConfiguration commitTimeout(long commitTimeout, TimeUnit unit) {
+    this.commitTimeout = unit.toSeconds(commitTimeout);
     return this;
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
@@ -15,6 +15,7 @@ class StreamResourceSupport {
   private static final String PARAM_STREAM_LIMIT = "stream_limit";
   private static final String PARAM_BATCH_FLUSH_TIMEOUT = "batch_flush_timeout";
   private static final String PARAM_STREAM_TIMEOUT = "stream_timeout";
+  private static final String PARAM_COMMIT_TIMEOUT = "commit_timeout";
   private static final String PARAM_STREAM_KEEP_ALIVE_LIMIT = "stream_keep_alive_limit";
   private static final String PARAM_MAX_UNCOMMITTED_EVENTS = "max_uncommitted_events";
   private static final String PATH_EVENT_TYPES = "event-types";
@@ -76,6 +77,7 @@ class StreamResourceSupport {
    * <li>batch_flush_timeout: {@link StreamConfiguration#batchFlushTimeoutSeconds()}</li>
    * <li>stream_timeout: {@link StreamConfiguration#streamTimeoutSeconds()}</li>
    * <li>stream_keep_alive_limit: {@link StreamConfiguration#streamKeepAliveLimit()}</li>
+   * <li>commit_timeout: {@link StreamConfiguration#commitTimeoutSeconds()}</li>
    * </ul>
    *
    * Only values not matching the defaults are set.
@@ -101,6 +103,10 @@ class StreamResourceSupport {
 
     if (sc.streamKeepAliveLimit() != StreamConfiguration.DEFAULT_STREAM_KEEPALIVE_COUNT) {
       uriBuilder.query(PARAM_STREAM_KEEP_ALIVE_LIMIT, "" + sc.streamKeepAliveLimit());
+    }
+
+    if (sc.commitTimeoutSeconds() != StreamConfiguration.DEFAULT_COMMIT_TIMEOUT) {
+      uriBuilder.query(PARAM_COMMIT_TIMEOUT, "" + sc.commitTimeoutSeconds());
     }
 
     return uriBuilder;


### PR DESCRIPTION
Adds commit_timeout parameter to configuration as described here:
https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*commit_timeout