### PR TITLE
Publish to oss.sonatype.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,12 @@
 plugins {
   id 'java'
   id 'idea'
-  id 'com.github.johnrengelman.shadow' version '7.1.0'
-  id 'nebula.project' version '9.2.1'
-  id 'nebula.dependency-lock' version "12.1.5"
-  id 'nebula.maven-publish' version '18.1.0'
+  id 'signing'
+  id 'maven-publish'
   id 'nebula.javadoc-jar' version '18.1.0'
   id 'nebula.source-jar' version '18.1.0'
-  id 'nebula.maven-shadow-publish' version '18.1.0'
-  id 'nebula.gradle-git-scm' version '5.0.0'
-  id 'nebula.nebula-bintray' version '8.5.0'
-  id 'nebula.release' version '16.0.0'
+  id 'com.github.johnrengelman.shadow' version '7.1.0'
+  id 'nebula.dependency-lock' version "12.1.5"
 }
 
 apply plugin: 'nebula.dependency-lock'
@@ -31,20 +27,35 @@ allprojects {
 
   apply plugin: 'java'
   apply plugin: 'idea'
-  apply plugin: 'com.github.johnrengelman.shadow'
-  apply plugin: 'nebula.project'
-  apply plugin: 'nebula.dependency-lock'
-  apply plugin: 'nebula.maven-publish'
+  apply plugin: 'signing'
+  apply plugin: 'maven-publish'
   apply plugin: 'nebula.javadoc-jar'
   apply plugin: 'nebula.source-jar'
-  apply plugin: "nebula.nebula-bintray"
-  apply plugin: "nebula.gradle-git-scm"
-  apply plugin: 'nebula.release'
+  apply plugin: 'nebula.dependency-lock'
 
   idea {
     module {
       downloadSources = true
       downloadJavadoc = true
+    }
+  }
+
+  publishing {
+    repositories {
+      maven {
+
+        def releasesRepoUrl = 'https://oss.sonatype.org/content/repositories/releases/'
+        def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+
+        url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+        ext.sonatypeUsername = project.properties.ossrhUsername
+        ext.sonatypePassword = project.properties.ossrhPassword
+        credentials {
+          username sonatypeUsername
+          password sonatypePassword
+        }
+      }
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,35 +1,22 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    jcenter()
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.3'
-    classpath 'org.apache.ant:ant:1.9.7' // resolve shadow and nebula deps
-    classpath "com.netflix.nebula:nebula-publishing-plugin:4.9.1"
-    classpath "com.netflix.nebula:nebula-project-plugin:3.3.0"
-    classpath "com.netflix.nebula:nebula-release-plugin:4.1.0"
-    classpath "com.netflix.nebula:nebula-bintray-plugin:3.5.0"
-    classpath "com.netflix.nebula:gradle-git-scm-plugin:3.0.1"
-  }
+plugins {
+  id 'java'
+  id 'idea'
+  id 'com.github.johnrengelman.shadow' version '7.1.0'
+  id 'nebula.project' version '9.2.1'
+  id 'nebula.dependency-lock' version "12.1.5"
+  id 'nebula.maven-publish' version '18.1.0'
+  id 'nebula.javadoc-jar' version '18.1.0'
+  id 'nebula.source-jar' version '18.1.0'
+  id 'nebula.maven-shadow-publish' version '18.1.0'
+  id 'nebula.gradle-git-scm' version '5.0.0'
+  id 'nebula.nebula-bintray' version '8.5.0'
+  id 'nebula.release' version '16.0.0'
 }
 
-apply plugin: 'java'
-apply plugin: 'idea'
-apply plugin: 'nebula.project'
 apply plugin: 'nebula.dependency-lock'
-apply plugin: 'nebula.maven-publish'
-apply plugin: 'nebula.javadoc-jar'
-apply plugin: 'nebula.source-jar'
-apply plugin: "nebula.nebula-bintray"
-apply plugin: "nebula.gradle-git-scm"
-//apply plugin: 'nebula.release'
 
-task wrapper(type: Wrapper) {
-  gradleVersion = '3.1'
+wrapper {
+  gradleVersion = '7.3'
 }
 
 apply from: "$rootDir/gradle/libs.gradle"
@@ -40,11 +27,11 @@ allprojects {
 
   repositories {
     mavenCentral()
-    jcenter()
   }
 
   apply plugin: 'java'
   apply plugin: 'idea'
+  apply plugin: 'com.github.johnrengelman.shadow'
   apply plugin: 'nebula.project'
   apply plugin: 'nebula.dependency-lock'
   apply plugin: 'nebula.maven-publish'
@@ -52,25 +39,12 @@ allprojects {
   apply plugin: 'nebula.source-jar'
   apply plugin: "nebula.nebula-bintray"
   apply plugin: "nebula.gradle-git-scm"
-  //apply plugin: 'nebula.release'
+  apply plugin: 'nebula.release'
 
   idea {
     module {
       downloadSources = true
       downloadJavadoc = true
     }
-  }
-}
-
-/*
-* Allows bintrayUpload to run from the project root without gradle complaining (the root project
-* doesn't have a bintrayUpload task).
-*/
-project.afterEvaluate {
-  //noinspection GrUnresolvedAccess
-  //noinspection GroovyAssignabilityCheck
-  task bintrayUpload(group: "publishing", overwrite: true) {
-    def projects = subprojects.findAll { it.name != "client-spike" }
-    dependsOn projects.bintrayUpload
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.15.0
+version=0.16.0-SNAPSHOT
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -5,7 +5,7 @@ ext {
 
 // uses dependency-lock syntax
 versions += [
-  guava: "19.+",
+  guava: "19.0",
   gson: "2.8.0",
   junit: "4.+",
   metrics: "3.1.0", // depends on slf4j, don't use for now

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 17 18:59:51 IST 2016
+#Mon Nov 22 18:13:29 GMT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip

--- a/nakadi-java-client/build.gradle
+++ b/nakadi-java-client/build.gradle
@@ -1,29 +1,17 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    mavenLocal()
-    jcenter()
-  }
-}
-
-apply plugin: "application"
-apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-  compile project.libs.guava
-  compile project.libs.gson
-  compile project.libs.okhttp3
-  compile project.libs.okhttp3log
-  compile project.libs.rxjava2
-  compile project.libs.slf4j
+  implementation project.libs.guava
+  implementation project.libs.gson
+  implementation project.libs.okhttp3
+  implementation project.libs.okhttp3log
+  implementation project.libs.rxjava2
+  implementation project.libs.slf4j
 
-  testCompile project.libs.junit
-  testCompile project.libs.slf4j
-  testCompile project.libs.logback_core
-  testCompile project.libs.logback_classic
-  testCompile project.libs.mockito_core
-  testCompile project.libs.okhttp3mockwebserver
-
+  testImplementation project.libs.junit
+  testImplementation project.libs.logback_core
+  testImplementation project.libs.logback_classic
+  testImplementation project.libs.mockito_core
+  testImplementation project.libs.okhttp3mockwebserver
 }
 
 sourceSets {
@@ -33,12 +21,6 @@ sourceSets {
     }
   }
 }
-
-/*
-* shadowJar needs `mainClassName` to complete
-*/
-//noinspection GroovyUnusedAssignment
-mainClassName = "nakadi.NakadiClientMain"
 
 /*
 * Don't publish spike classes for source or java doc
@@ -79,59 +61,5 @@ shadowJar {
 * Give the bintray task our shadow jar via `shadowedJar`. This has all its dependencies embedded and
 * shaded. We have to add the source and javadoc artifacts as well.
 */
-publishing {
-  publications {
-    shadow(MavenPublication) { publication ->
-      project.shadow.component(publication)
-      groupId project.group
-      artifactId = project.name
-      version = project.version
 
-      artifact(sourceJar) {
-      }
-      artifact(javadocJar) {
-      }
-    }
-  }
-}
 
-/*
- * nebula/bintray gets stuck sometimes; `gradle --stop; gradle clean` can help
-*/
-bintray {
-  // verbose to let these eval to empty when not being used; `project.property` isn't lazy
-  user = project.hasProperty('bintray_user') ? project.property('bintray_user') :
-    System.getenv('BINTRAY_USER')
-  key = project.hasProperty('bintray_key') ? project.property('bintray_key') :
-    System.getenv('BINTRAY_KEY')
-
-  publications = ['shadow'] // use our publishing setup from above
-  dryRun = false
-  publish = true
-
-  pkg {
-    repo = 'maven'
-    userOrg = 'dehora'
-    name = 'nakadi-java-client'
-    desc = 'Java driver for the Nakadi API'
-    websiteUrl = 'https://zalando-incubator.github.io/nakadi-java/'
-    issueTrackerUrl = 'https://github.com/zalando-incubator/nakadi-java/issues'
-    vcsUrl = 'https://github.com/zalando-incubator/nakadi-java.git'
-    licenses = ['MIT']
-    labels = ['nakadi', 'java', 'api']
-    publicDownloadNumbers = true
-
-    //noinspection GroovyAssignabilityCheck
-    version {
-      name = project.version
-      vcsTag = project.version
-      attributes = [:]
-      gpg {
-        //noinspection GroovyAssignabilityCheck
-        sign = true
-        passphrase = project.hasProperty('bintray_gpg_passphrase') ?
-          project.property('bintray_gpg_passphrase') : System.getenv('BINTRAY_GPG_PASSPHRASE')
-      }
-    }
-  }
-}

--- a/nakadi-java-client/build.gradle
+++ b/nakadi-java-client/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
   implementation project.libs.guava
@@ -37,15 +38,17 @@ sourceJar {
 * Shade our dependencies; rx, gson, guava and okhttp3 have no transitive
 * dependencies to cascade into
 */
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
+
+task relocateShadowJar(type: ConfigureShadowRelocation) {
+  target = tasks.shadowJar
+  prefix = "nakadi.shadow"
+}
+
+tasks.shadowJar.dependsOn tasks.relocateShadowJar
+
 shadowJar {
-  relocate "com.google.gson", "nakadi.shadow.com.google.gson"
-  relocate "com.google.common", "nakadi.shadow.com.google.common"
-  relocate "com.google.thirdparty", "nakadi.shadow.com.google.thirdparty"
-  relocate "rx", "nakadi.shadow.rx"
-  relocate "io.reactivex", "nakadi.shadow.io.reactivex"
-  relocate "org.reactivestreams", "nakadi.shadow.org.reactivestreams"
-  relocate "okhttp3", "nakadi.shadow.okhttp3"
-  relocate "okio", "nakadi.shadow.okio"
   classifier = '' // remove the default all suffix to name it like a regular lib jar
   exclude 'net/dehora/nakadi/client/spike/**'
   exclude 'org/slf4j/**'
@@ -57,9 +60,37 @@ shadowJar {
   exclude 'rxjava.properties'
 }
 
-/*
-* Give the bintray task our shadow jar via `shadowedJar`. This has all its dependencies embedded and
-* shaded. We have to add the source and javadoc artifacts as well.
-*/
+publishing {
+  publications {
+    shadow(MavenPublication) { publication ->
+      project.shadow.component(publication)
 
+      artifact(sourceJar) {
+      }
 
+      artifact(javadocJar) {
+      }
+
+      pom {
+
+        url = 'https://github.com/dehora/nakadi-java'
+
+        description = 'Client driver for Nakadi'
+
+        licenses {
+          license {
+            name = 'MIT License'
+          }
+        }
+
+        scm {
+          url = 'git@github.com:dehora/nakadi-java.git'
+        }
+      }
+    }
+  }
+}
+
+signing {
+  sign publishing.publications.shadow
+}

--- a/nakadi-java-client/build.gradle
+++ b/nakadi-java-client/build.gradle
@@ -38,17 +38,15 @@ sourceJar {
 * Shade our dependencies; rx, gson, guava and okhttp3 have no transitive
 * dependencies to cascade into
 */
-
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
-
-task relocateShadowJar(type: ConfigureShadowRelocation) {
-  target = tasks.shadowJar
-  prefix = "nakadi.shadow"
-}
-
-tasks.shadowJar.dependsOn tasks.relocateShadowJar
-
 shadowJar {
+  relocate "com.google.gson", "nakadi.shadow.com.google.gson"
+  relocate "com.google.common", "nakadi.shadow.com.google.common"
+  relocate "com.google.thirdparty", "nakadi.shadow.com.google.thirdparty"
+  relocate "rx", "nakadi.shadow.rx"
+  relocate "io.reactivex", "nakadi.shadow.io.reactivex"
+  relocate "org.reactivestreams", "nakadi.shadow.org.reactivestreams"
+  relocate "okhttp3", "nakadi.shadow.okhttp3"
+  relocate "okio", "nakadi.shadow.okio"
   classifier = '' // remove the default all suffix to name it like a regular lib jar
   exclude 'net/dehora/nakadi/client/spike/**'
   exclude 'org/slf4j/**'

--- a/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
@@ -36,7 +36,6 @@ public class EventMetadata {
    *   The object is <b>not</b> prepared with any values, such eid, occurred at, and flow id. To
    *   create an EventMetadata with prepared values use {@link #newPreparedEventMetadata()}
    * </p>
-   * @return an EventMetadata
    */
   public EventMetadata() {
   }

--- a/nakadi-java-gson/build.gradle
+++ b/nakadi-java-gson/build.gradle
@@ -1,20 +1,14 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    mavenLocal()
-    jcenter()
-  }
-}
 
 
 dependencies {
-  compile project(':nakadi-java-client')
-  compile project.libs.gson
-  compile project.libs.slf4j
+  implementation project(':nakadi-java-client')
+  implementation project.libs.guava
+  implementation project.libs.gson
+  implementation project.libs.slf4j
 
-  testCompile project.libs.logback_core
-  testCompile project.libs.logback_classic
-  testCompile project.libs.junit
+  testImplementation project.libs.logback_core
+  testImplementation project.libs.logback_classic
+  testImplementation project.libs.junit
 }
 
 sourceSets {
@@ -24,45 +18,3 @@ sourceSets {
     }
   }
 }
-
-
-bintray {
-  // verbose to let these eval to empty when not being used; `project.property` isn't lazy
-  user = project.hasProperty('bintray_user') ? project.property('bintray_user') :
-    System.getenv('BINTRAY_USER')
-  key = project.hasProperty('bintray_key') ? project.property('bintray_key') :
-    System.getenv('BINTRAY_KEY')
-
-  publications = ['nebula'] // use our publishing setup from above
-  dryRun = false
-  publish = true
-
-  pkg {
-    repo = 'maven'
-    userOrg = 'dehora'
-    name = 'nakadi-java-gson'
-    desc = 'Gson provider for nakadi-java'
-    websiteUrl = 'https://zalando-incubator.github.io/nakadi-java/'
-    issueTrackerUrl = 'https://github.com/zalando-incubator/nakadi-java/issues'
-    vcsUrl = 'https://github.com/zalando-incubator/nakadi-java.git'
-    licenses = ['MIT']
-    labels = ['nakadi', 'java', 'api', 'gson']
-    publicDownloadNumbers = true
-
-    //noinspection GroovyAssignabilityCheck
-    version {
-      name = project.version
-      vcsTag = project.version
-      attributes = [:]
-      gpg {
-        //noinspection GroovyAssignabilityCheck
-        sign = true
-        passphrase = project.hasProperty('bintray_gpg_passphrase') ?
-          project.property('bintray_gpg_passphrase') : System.getenv('BINTRAY_GPG_PASSPHRASE')
-      }
-    }
-  }
-}
-
-
-

--- a/nakadi-java-gson/build.gradle
+++ b/nakadi-java-gson/build.gradle
@@ -18,3 +18,48 @@ sourceSets {
     }
   }
 }
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+
+      artifact(jar) {
+      }
+
+      artifact(sourceJar) {
+      }
+
+      artifact(javadocJar) {
+      }
+
+      pom.withXml {
+
+        asNode().with {
+          appendNode('url', 'https://github.com/dehora/nakadi-java')
+          appendNode('description', 'Client driver gson support')
+          appendNode('scm').with {
+            appendNode('url', 'git@github.com:dehora/nakadi-java.git')
+          }
+          appendNode('licenses').with {
+            appendNode('license').with {
+              appendNode('name', 'MIT License')
+            }
+          }
+        }
+
+        def dependenciesNode = asNode().appendNode('dependencies')
+        configurations.implementation.allDependencies.each {
+          def dependencyNode = dependenciesNode.appendNode('dependency')
+          dependencyNode.appendNode('groupId', it.group)
+          dependencyNode.appendNode('artifactId', it.name)
+          dependencyNode.appendNode('version', it.version)
+        }
+      }
+    }
+  }
+}
+
+signing {
+  sign publishing.publications.mavenJava
+}
+

--- a/nakadi-java-metrics/build.gradle
+++ b/nakadi-java-metrics/build.gradle
@@ -1,13 +1,56 @@
 
-
-
 dependencies {
-  implementation project(':nakadi-java-client')
+  implementation project(path: ':nakadi-java-client', configuration: 'shadow')
   implementation 'io.dropwizard:dropwizard-metrics:1.0.3'
   implementation 'io.micrometer:micrometer-core:1.5.1'
 
   testImplementation project.libs.junit
 }
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+
+      artifact(jar) {
+      }
+
+      artifact(sourceJar) {
+      }
+
+      artifact(javadocJar) {
+      }
+
+      pom.withXml {
+
+        asNode().with {
+          appendNode('url', 'https://github.com/dehora/nakadi-java')
+          appendNode('description', 'Client driver metrics support')
+          appendNode('scm').with {
+            appendNode('url', 'git@github.com:dehora/nakadi-java.git')
+          }
+          appendNode('licenses').with {
+            appendNode('license').with {
+              appendNode('name', 'MIT License')
+            }
+          }
+        }
+
+        def dependenciesNode = asNode().appendNode('dependencies')
+        configurations.implementation.allDependencies.each {
+          def dependencyNode = dependenciesNode.appendNode('dependency')
+          dependencyNode.appendNode('groupId', it.group)
+          dependencyNode.appendNode('artifactId', it.name)
+          dependencyNode.appendNode('version', it.version)
+        }
+      }
+    }
+  }
+}
+
+signing {
+  sign publishing.publications.mavenJava
+}
+
 
 
 

--- a/nakadi-java-metrics/build.gradle
+++ b/nakadi-java-metrics/build.gradle
@@ -1,57 +1,14 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    mavenLocal()
-    jcenter()
-  }
-}
+
 
 
 dependencies {
-  compile project(':nakadi-java-client')
-  compile 'io.dropwizard:dropwizard-metrics:1.0.3'
-  compile 'io.micrometer:micrometer-core:1.5.1'
+  implementation project(':nakadi-java-client')
+  implementation 'io.dropwizard:dropwizard-metrics:1.0.3'
+  implementation 'io.micrometer:micrometer-core:1.5.1'
 
-  testCompile project.libs.junit
+  testImplementation project.libs.junit
 }
 
-bintray {
-  // verbose to let these eval to empty when not being used; `project.property` isn't lazy
-  user = project.hasProperty('bintray_user') ? project.property('bintray_user') :
-    System.getenv('BINTRAY_USER')
-  key = project.hasProperty('bintray_key') ? project.property('bintray_key') :
-    System.getenv('BINTRAY_KEY')
-
-  publications = ['nebula'] // use our publishing setup from above
-  dryRun = false
-  publish = true
-
-  pkg {
-    repo = 'maven'
-    userOrg = 'dehora'
-    name = 'nakadi-java-metrics'
-    desc = 'Metric collectors for nakadi-java'
-    websiteUrl = 'https://zalando-incubator.github.io/nakadi-java/'
-    issueTrackerUrl = 'https://github.com/zalando-incubator/nakadi-java/issues'
-    vcsUrl = 'https://github.com/zalando-incubator/nakadi-java.git'
-    licenses = ['MIT']
-    labels = ['nakadi', 'java', 'api', 'metrics', 'dropwizard', 'micrometer']
-    publicDownloadNumbers = true
-
-    //noinspection GroovyAssignabilityCheck
-    version {
-      name = project.version
-      vcsTag = project.version
-      attributes = [:]
-      gpg {
-        //noinspection GroovyAssignabilityCheck
-        sign = true
-        passphrase = project.hasProperty('bintray_gpg_passphrase') ?
-          project.property('bintray_gpg_passphrase') : System.getenv('BINTRAY_GPG_PASSPHRASE')
-      }
-    }
-  }
-}
 
 
 

--- a/nakadi-java-zign/build.gradle
+++ b/nakadi-java-zign/build.gradle
@@ -1,19 +1,13 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    mavenLocal()
-    jcenter()
-  }
-}
 
 
 dependencies {
-  compile project(':nakadi-java-client')
-  compile project.libs.slf4j
+  implementation project(':nakadi-java-client')
+  implementation project.libs.slf4j
 
-  testCompile project.libs.logback_core
-  testCompile project.libs.logback_classic
-  testCompile project.libs.junit
+  testImplementation project.libs.guava
+  testImplementation project.libs.logback_core
+  testImplementation project.libs.logback_classic
+  testImplementation project.libs.junit
 }
 
 sourceSets {
@@ -28,44 +22,6 @@ jar {
   exclude 'logback-test.xml'
 }
 
-
-bintray {
-  // verbose to let these eval to empty when not being used; `project.property` isn't lazy
-  user = project.hasProperty('bintray_user') ? project.property('bintray_user') :
-    System.getenv('BINTRAY_USER')
-  key = project.hasProperty('bintray_key') ? project.property('bintray_key') :
-    System.getenv('BINTRAY_KEY')
-
-  publications = ['nebula'] // use our publishing setup from above
-  dryRun = false
-  publish = true
-
-  pkg {
-    repo = 'maven'
-    userOrg = 'dehora'
-    name = 'nakadi-java-zign'
-    desc = 'Zign token provider for nakadi-java'
-    websiteUrl = 'https://zalando-incubator.github.io/nakadi-java/'
-    issueTrackerUrl = 'https://github.com/zalando-incubator/nakadi-java/issues'
-    vcsUrl = 'https://github.com/zalando-incubator/nakadi-java.git'
-    licenses = ['MIT']
-    labels = ['nakadi', 'java', 'api', 'zign']
-    publicDownloadNumbers = true
-
-    //noinspection GroovyAssignabilityCheck
-    version {
-      name = project.version
-      vcsTag = project.version
-      attributes = [:]
-      gpg {
-        //noinspection GroovyAssignabilityCheck
-        sign = true
-        passphrase = project.hasProperty('bintray_gpg_passphrase') ?
-          project.property('bintray_gpg_passphrase') : System.getenv('BINTRAY_GPG_PASSPHRASE')
-      }
-    }
-  }
+sourceJar {
+  exclude 'logback-test.xml'
 }
-
-
-

--- a/nakadi-java-zign/build.gradle
+++ b/nakadi-java-zign/build.gradle
@@ -25,3 +25,49 @@ jar {
 sourceJar {
   exclude 'logback-test.xml'
 }
+
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+
+      artifact(jar) {
+      }
+
+      artifact(sourceJar) {
+      }
+
+      artifact(javadocJar) {
+      }
+
+      pom.withXml {
+
+        asNode().with {
+          appendNode('url', 'https://github.com/dehora/nakadi-java')
+          appendNode('description', 'Client driver zign support')
+          appendNode('scm').with {
+            appendNode('url', 'git@github.com:dehora/nakadi-java.git')
+          }
+          appendNode('licenses').with {
+            appendNode('license').with {
+              appendNode('name', 'MIT License')
+            }
+          }
+        }
+
+        def dependenciesNode = asNode().appendNode('dependencies')
+        configurations.implementation.allDependencies.each {
+          def dependencyNode = dependenciesNode.appendNode('dependency')
+          dependencyNode.appendNode('groupId', it.group)
+          dependencyNode.appendNode('artifactId', it.name)
+          dependencyNode.appendNode('version', it.version)
+        }
+      }
+    }
+  }
+}
+
+signing {
+  sign publishing.publications.mavenJava
+}
+


### PR DESCRIPTION
Converts the build to publish to sonatype
    
This replaces the bintray publication (bintray is gone) with a  maven publication to sonatype. In doing so it upgrades to use  more recent versions of gradle, shadow, and nebula plugins. It also adds signing support required by sonatype. The build's jar packaging step has to be rewritten as a result rather than just changing the publish target, so the version will get a major bump (effectively a promotion to 0.16 from 0.15) to be on the safe side.
