### PR TITLE
Add support Avro publishing

### DIFF
--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -13,7 +13,8 @@ versions += [
   rxjava2: "2.0.9",
   slf4j: "1.8.0-beta2",
   logback: "1.3.0-alpha5",
-  mockito: "1.+"
+  mockito: "1.+",
+  avro: "1.11.1"
 ]
 
 libs += [
@@ -29,7 +30,8 @@ libs += [
   slf4jsimple: "org.slf4j:slf4j-simple:$versions.slf4j",
   logback_core: "ch.qos.logback:logback-core:$versions.logback",
   logback_classic: "ch.qos.logback:logback-classic:$versions.logback",
-  mockito_core: "org.mockito:mockito-core:$versions.mockito"
+  mockito_core: "org.mockito:mockito-core:$versions.mockito",
+  avro: "org.apache.avro:avro:$versions.avro"
 ]
 
 ext {

--- a/nakadi-java-client/build.gradle
+++ b/nakadi-java-client/build.gradle
@@ -1,4 +1,9 @@
+plugins {
+  id "com.github.davidmc24.gradle.plugin.avro" version "1.3.0"
+}
+
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: "com.github.davidmc24.gradle.plugin.avro-base"
 
 dependencies {
   implementation project.libs.guava
@@ -7,6 +12,7 @@ dependencies {
   implementation project.libs.okhttp3log
   implementation project.libs.rxjava2
   implementation project.libs.slf4j
+  implementation project.libs.avro
 
   testImplementation project.libs.junit
   testImplementation project.libs.logback_core
@@ -16,6 +22,11 @@ dependencies {
 }
 
 sourceSets {
+  main {
+    java {
+      srcDirs = ["src/main/java", "build/generated/sources"]
+    }
+  }
   test {
     java {
       srcDir 'src/test/resources'
@@ -102,4 +113,15 @@ publishing {
 
 signing {
   sign publishing.publications.shadow
+}
+
+import com.github.davidmc24.gradle.plugin.avro.GenerateAvroJavaTask
+
+def generateAvro = tasks.register("generateAvro", GenerateAvroJavaTask) {
+  source("src/main/resources/nakadi-envelope-schema", "src/test/resources/avro-schemas")
+  outputDir = file("build/generated/sources")
+}
+
+tasks.named("compileJava").configure {
+  source(generateAvro)
 }

--- a/nakadi-java-client/src/main/java/nakadi/AvroPayloadSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/AvroPayloadSerializer.java
@@ -10,6 +10,7 @@ import org.zalando.nakadi.generated.avro.PublishingBatch;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -18,11 +19,11 @@ public class AvroPayloadSerializer implements PayloadSerializer {
 
     private Map<String, EventTypeSchemaPair<Schema>> etSchemas;
     public AvroPayloadSerializer(Map<String, EventTypeSchemaPair<Schema>> etSchemas) {
-    this.etSchemas = etSchemas;
+        this.etSchemas = etSchemas;
     }
 
     @Override
-    public <T> byte[] toBytes(final List<T> events) {
+    public <T> byte[] toBytes(final String eventTypeName, final Collection<T> events) {
         try {
             final List<Envelope> envelops = events.stream()
                     .map(event -> {
@@ -58,11 +59,6 @@ public class AvroPayloadSerializer implements PayloadSerializer {
         } catch (IOException io) {
             throw new RuntimeException();
         }
-    }
-
-    @Override
-    public <T> Object transformEventRecord(EventRecord<T> eventRecord) {
-        return eventRecord.event();
     }
 
     @Override

--- a/nakadi-java-client/src/main/java/nakadi/AvroPayloadSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/AvroPayloadSerializer.java
@@ -1,0 +1,75 @@
+package nakadi;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.zalando.nakadi.generated.avro.Envelope;
+import org.zalando.nakadi.generated.avro.Metadata;
+import org.zalando.nakadi.generated.avro.PublishingBatch;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AvroPayloadSerializer implements PayloadSerializer {
+
+    private final String eventType;
+    private final String schemaVersion;
+    private final Schema schema;
+
+    public AvroPayloadSerializer(final String eventType,
+                                 final String schemaVersion,
+                                 final Schema schema) {
+        this.eventType = eventType;
+        this.schemaVersion = schemaVersion;
+        this.schema = schema;
+    }
+
+    @Override
+    public <T> byte[] toBytes(final List<T> events) {
+        try {
+            final List<Envelope> envelops = events.stream()
+                    .map(event -> {
+                        EventEnvelope realEvent = (EventEnvelope) event;
+                        try {
+                            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                            new GenericDatumWriter(schema).write(realEvent.getData(),
+                                    EncoderFactory.get().directBinaryEncoder(baos, null));
+                            final EventMetadata metadata = realEvent.getMetadata();
+
+                            return Envelope.newBuilder()
+                                    .setMetadata(Metadata.newBuilder()
+                                            .setEventType(metadata.eventType())
+                                            .setVersion(schemaVersion)
+                                            .setOccurredAt(metadata.occurredAt().toInstant())
+                                            .setEid(metadata.eid())
+                                            .setPartition(metadata.partition())
+                                            .setPartitionCompactionKey(metadata.partitionCompactionKey())
+                                            .build())
+                                    .setPayload(ByteBuffer.wrap(baos.toByteArray()))
+                                    .build();
+                        } catch (IOException io) {
+                            throw new RuntimeException();
+                        }
+                    })
+                    .collect(Collectors.toList());
+            return PublishingBatch.newBuilder().setEvents(envelops)
+                    .build().toByteBuffer().array();
+        } catch (IOException io) {
+            throw new RuntimeException();
+        }
+    }
+
+    @Override
+    public <T> Object transformEventRecord(EventRecord<T> eventRecord) {
+        return eventRecord.event();
+    }
+
+    @Override
+    public String payloadMimeType() {
+        return "application/avro-binary";
+    }
+}

--- a/nakadi-java-client/src/main/java/nakadi/EventEnvelope.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventEnvelope.java
@@ -1,0 +1,19 @@
+package nakadi;
+
+public class EventEnvelope<T> {
+    private final T data;
+    private final EventMetadata metadata;
+
+    public EventEnvelope(final T data, final EventMetadata metadata) {
+        this.data = data;
+        this.metadata = metadata;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public EventMetadata getMetadata() {
+        return metadata;
+    }
+}

--- a/nakadi-java-client/src/main/java/nakadi/EventEnvelope.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventEnvelope.java
@@ -1,6 +1,8 @@
 package nakadi;
 
-public class EventEnvelope<T> {
+import org.apache.avro.generic.GenericRecord;
+
+public class EventEnvelope<T extends GenericRecord> implements Event<T>{
     private final T data;
     private final EventMetadata metadata;
 
@@ -9,7 +11,7 @@ public class EventEnvelope<T> {
         this.metadata = metadata;
     }
 
-    public T getData() {
+    public T data() {
         return data;
     }
 

--- a/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
@@ -237,6 +237,17 @@ public class EventMetadata {
   }
 
   /**
+   * Set the schema version of the event.
+   *
+   * @param version schema version of the event
+   * @return this
+   */
+  public EventMetadata version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  /**
    * The version of the schema used to validate this event.
    *
    * @return the version.

--- a/nakadi-java-client/src/main/java/nakadi/EventResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResource.java
@@ -1,7 +1,6 @@
 package nakadi;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
@@ -111,7 +111,7 @@ public class EventResourceReal implements EventResource {
 
   @Override
   public final <T> Response send(String eventTypeName, Collection<T> events) {
-    return send(eventTypeName,events, SENTINEL_HEADERS);
+    return send(eventTypeName, events, SENTINEL_HEADERS);
   }
 
   @Override public <T> Response send(String eventTypeName, Collection<T> events,

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
@@ -199,7 +199,7 @@ public interface EventTypeResource {
   CursorDistanceCollection distance(String eventTypeName, List<CursorDistance> cursorDistanceList);
 
   /**
-   * Check the the number of unconsumed events for each cursor's partition.
+   * Check the number of unconsumed events for each cursor's partition.
    *
    * @param eventTypeName the event type
    * @param cursors the cursors to check.
@@ -207,11 +207,38 @@ public interface EventTypeResource {
    */
   PartitionCollection lag(String eventTypeName, List<Cursor> cursors);
 
+  /**
+   * Create a Schema resource.
+   *
+   * @param eventTypeName
+   * @param eventTypeSchema
+   * @return
+   * @throws AuthorizationException
+   * @throws ClientException
+   * @throws ServerException
+   * @throws InvalidException
+   * @throws RateLimitException
+   * @throws NakadiException
+   */
   Response createSchema(String eventTypeName, EventTypeSchema eventTypeSchema)
           throws AuthorizationException, ClientException, ServerException, InvalidException,
           RateLimitException, NakadiException;
 
-  Optional<EventTypeSchema> fetchSchema(String eventTypeName, EventTypeSchema eventTypeSchema)
+  /**
+   * Fetches a schema that matches the one supplied in the argument. The EventTypeSchema returned
+   * has the version field filled.
+   *
+   * @param eventTypeName
+   * @param eventTypeSchema
+   * @return
+   * @throws AuthorizationException
+   * @throws ClientException
+   * @throws ServerException
+   * @throws InvalidException
+   * @throws RateLimitException
+   * @throws NakadiException
+   */
+  Optional<EventTypeSchema> fetchMatchingSchema(String eventTypeName, EventTypeSchema eventTypeSchema)
           throws AuthorizationException, ClientException, ServerException, InvalidException,
           RateLimitException, NakadiException;;
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
@@ -206,4 +206,12 @@ public interface EventTypeResource {
    * @return the result from the server.
    */
   PartitionCollection lag(String eventTypeName, List<Cursor> cursors);
+
+  Response createSchema(String eventTypeName, EventTypeSchema eventTypeSchema)
+          throws AuthorizationException, ClientException, ServerException, InvalidException,
+          RateLimitException, NakadiException;
+
+  Optional<EventTypeSchema> fetchSchema(String eventTypeName, EventTypeSchema eventTypeSchema)
+          throws AuthorizationException, ClientException, ServerException, InvalidException,
+          RateLimitException, NakadiException;;
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
@@ -54,7 +54,7 @@ class EventTypeResourceReal implements EventTypeResource {
       RateLimitException, NakadiException {
 
     // todo: close
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -66,7 +66,7 @@ class EventTypeResourceReal implements EventTypeResource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, NakadiException {
     String url = collectionUri().path(eventType.name()).buildString();
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     // todo: close
     return client.resourceProvider()
         .newResource()
@@ -159,7 +159,7 @@ class EventTypeResourceReal implements EventTypeResource {
     NakadiException.throwNotNullOrEmpty(cursorList, "Please provide at least one cursor");
 
     final String url = collectionUri().path(eventTypeName).path(PATH_CURSOR_SHIFTS).buildString();
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     final Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -177,7 +177,7 @@ class EventTypeResourceReal implements EventTypeResource {
       String eventTypeName, List<CursorDistance> cursorDistanceList) {
 
     final String url = collectionUri().path(eventTypeName).path(PATH_CURSOR_DISTANCE).buildString();
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     final Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -192,7 +192,7 @@ class EventTypeResourceReal implements EventTypeResource {
 
   @Override public PartitionCollection lag(String eventTypeName, List<Cursor> cursors) {
     final String url = collectionUri().path(eventTypeName).path("cursors-lag").buildString();
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
 
     final Response response = client.resourceProvider()
         .newResource()

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
@@ -269,7 +269,7 @@ class EventTypeResourceReal implements EventTypeResource {
   }
 
   @Override
-  public Optional<EventTypeSchema> fetchSchema(String eventTypeName, EventTypeSchema eventTypeSchema)
+  public Optional<EventTypeSchema> fetchMatchingSchema(String eventTypeName, EventTypeSchema eventTypeSchema)
           throws AuthorizationException, ClientException, ServerException, InvalidException,
           RateLimitException, NakadiException {
 

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeSchema.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeSchema.java
@@ -40,6 +40,11 @@ public class EventTypeSchema {
     return version;
   }
 
+  public EventTypeSchema version(String version) {
+    this.version = version;
+    return this;
+  }
+
   /**
    * @return the time the event type was created.
    */
@@ -71,6 +76,7 @@ public class EventTypeSchema {
   }
 
   public enum Type {
-    json_schema
+    json_schema,
+    avro_schema
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeSchemaPair.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeSchemaPair.java
@@ -1,0 +1,70 @@
+package nakadi;
+
+import java.util.Objects;
+
+public class EventTypeSchemaPair<T> {
+
+    private String eventTypeName;
+    private T schema;
+    private String version;
+
+    public EventTypeSchemaPair(){
+
+    }
+
+    public String eventTypeName() {
+        return eventTypeName;
+    }
+
+    public EventTypeSchemaPair<T> eventTypeName(String eventTypeName) {
+        this.eventTypeName = eventTypeName;
+        return this;
+    }
+
+    public T schema() {
+        return schema;
+    }
+
+    public EventTypeSchemaPair<T> schema(T schema) {
+        this.schema = schema;
+        return this;
+    }
+
+    public String version() {
+        return version;
+    }
+
+    public EventTypeSchemaPair<T> version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EventTypeSchemaPair<?> that = (EventTypeSchemaPair<?>) o;
+
+        if (!eventTypeName.equals(that.eventTypeName)) return false;
+        if (!schema.equals(that.schema)) return false;
+        return Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = eventTypeName.hashCode();
+        result = 31 * result + schema.hashCode();
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "EventTypeSchemaPair{" +
+                "eventTypeName='" + eventTypeName + '\'' +
+                ", schema=" + schema +
+                ", version='" + version + '\'' +
+                '}';
+    }
+}

--- a/nakadi-java-client/src/main/java/nakadi/InvalidEventTypeException.java
+++ b/nakadi-java-client/src/main/java/nakadi/InvalidEventTypeException.java
@@ -1,0 +1,8 @@
+package nakadi;
+
+public class InvalidEventTypeException extends RuntimeException {
+
+    public InvalidEventTypeException(String message) {
+        super(message);
+    }
+}

--- a/nakadi-java-client/src/main/java/nakadi/InvalidSchemaException.java
+++ b/nakadi-java-client/src/main/java/nakadi/InvalidSchemaException.java
@@ -1,0 +1,8 @@
+package nakadi;
+
+public class InvalidSchemaException extends RuntimeException{
+
+    public InvalidSchemaException(String message){
+        super(message);
+    }
+}

--- a/nakadi-java-client/src/main/java/nakadi/JsonPayloadSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/JsonPayloadSerializer.java
@@ -1,6 +1,8 @@
 package nakadi;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class JsonPayloadSerializer implements PayloadSerializer {
 
@@ -11,13 +13,13 @@ public class JsonPayloadSerializer implements PayloadSerializer {
     }
 
     @Override
-    public <T> byte[] toBytes(List<T> o) {
-        return jsonSupport.toJsonBytesCompressed(o);
-    }
+    public <T> byte[] toBytes(String eventTypeName, Collection<T> events) {
+        List<EventRecord<T>> collect =
+                events.stream().map(e -> new EventRecord<>(eventTypeName, e)).collect(Collectors.toList());
+        List<Object> eventList =
+                collect.stream().map(jsonSupport::transformEventRecord).collect(Collectors.toList());
 
-    @Override
-    public <T> Object transformEventRecord(EventRecord<T> eventRecord) {
-        return jsonSupport.transformEventRecord(eventRecord);
+        return jsonSupport.toJsonBytesCompressed(eventList);
     }
 
     @Override

--- a/nakadi-java-client/src/main/java/nakadi/JsonPayloadSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/JsonPayloadSerializer.java
@@ -1,0 +1,28 @@
+package nakadi;
+
+import java.util.List;
+
+public class JsonPayloadSerializer implements PayloadSerializer {
+
+    private final JsonSupport jsonSupport;
+
+    public JsonPayloadSerializer(final JsonSupport jsonSupport) {
+        this.jsonSupport = jsonSupport;
+    }
+
+    @Override
+    public <T> byte[] toBytes(List<T> o) {
+        return jsonSupport.toJsonBytesCompressed(o);
+    }
+
+    @Override
+    public <T> Object transformEventRecord(EventRecord<T> eventRecord) {
+        return jsonSupport.transformEventRecord(eventRecord);
+    }
+
+    @Override
+    public String payloadMimeType() {
+        return "application/json";
+    }
+
+}

--- a/nakadi-java-client/src/main/java/nakadi/JsonPayloadSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/JsonPayloadSerializer.java
@@ -22,7 +22,7 @@ public class JsonPayloadSerializer implements PayloadSerializer {
 
     @Override
     public String payloadMimeType() {
-        return "application/json";
+        return "application/json; charset=utf8";
     }
 
 }

--- a/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
@@ -21,7 +21,6 @@ class OkHttpResource implements Resource {
   private static final Logger logger = LoggerFactory.getLogger(NakadiClient.class.getSimpleName());
 
   private static final String HEADER_AUTHORIZATION = "Authorization";
-  private static final String APPLICATION_JSON_CHARSET_UTF8 = "application/json; charset=utf8";
 
   private final OkHttpClient okHttpClient;
   private final JsonSupport jsonSupport;
@@ -197,8 +196,9 @@ class OkHttpResource implements Resource {
     Request.Builder builder;
     if (body != null) {
       {
+
         RequestBody requestBody =
-            RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF8), body.content());
+            RequestBody.create(MediaType.parse((String) options.headers().get("Content-Type")), body.content());
         builder = new Request.Builder().url(url).method(method, requestBody);
       }
     } else {

--- a/nakadi-java-client/src/main/java/nakadi/PayloadSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/PayloadSerializer.java
@@ -1,12 +1,10 @@
 package nakadi;
 
-import java.util.List;
+import java.util.Collection;
 
 public interface PayloadSerializer {
 
-    <T> byte[] toBytes(List<T> o);
-
-    <T> Object transformEventRecord(EventRecord<T> eventRecord);
+    <T> byte[] toBytes(String eventTypeName, Collection<T> o);
 
     String payloadMimeType();
 }

--- a/nakadi-java-client/src/main/java/nakadi/PayloadSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/PayloadSerializer.java
@@ -1,0 +1,12 @@
+package nakadi;
+
+import java.util.List;
+
+public interface PayloadSerializer {
+
+    <T> byte[] toBytes(List<T> o);
+
+    <T> Object transformEventRecord(EventRecord<T> eventRecord);
+
+    String payloadMimeType();
+}

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -21,4 +21,9 @@ class ResourceSupport {
         .header("User-Agent", NakadiClient.USER_AGENT)
         .flowId(ResourceSupport.nextFlowId());
   }
+
+  public static ResourceOptions optionsWithJsonContent(ResourceOptions options) {
+    return options.header("Content-Type", "application/json; charset=utf8");
+  }
+
 }

--- a/nakadi-java-client/src/main/java/nakadi/Resources.java
+++ b/nakadi-java-client/src/main/java/nakadi/Resources.java
@@ -1,5 +1,7 @@
 package nakadi;
 
+import org.apache.avro.Schema;
+
 /**
  * Allows access to the API via resource classes.
  */
@@ -47,6 +49,20 @@ public class Resources {
    */
   public EventResource events() {
     return new EventResourceReal(client);
+  }
+
+  /**
+   * The resource for binary events
+   *
+   * @return a resource for working with events
+   */
+  public EventResource eventsBinary(final String eventType,
+                                    final String schemaVersion,  // TODO have a look at it again, maybe the check should be inside the method
+                                    final Schema schema) {
+    return new EventResourceReal(client,
+            client.jsonSupport(),
+            client.compressionSupport(),
+            new AvroPayloadSerializer(eventType, schemaVersion, schema));
   }
 
   /**

--- a/nakadi-java-client/src/main/java/nakadi/Resources.java
+++ b/nakadi-java-client/src/main/java/nakadi/Resources.java
@@ -3,7 +3,6 @@ package nakadi;
 import org.apache.avro.Schema;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +71,7 @@ public class Resources {
     EventTypeResource etResource = eventTypes();
     Map<String, EventTypeSchemaPair<Schema>> etSchemaMap = new HashMap<>();
     Function<EventTypeSchemaPair<Schema>, Optional<EventTypeSchema>> toSchema =
-            (etS) -> etResource.fetchSchema(etS.eventTypeName(), new EventTypeSchema().schema(etS.schema().toString()).type(avro_schema));
+            (etS) -> etResource.fetchMatchingSchema(etS.eventTypeName(), new EventTypeSchema().schema(etS.schema().toString()).type(avro_schema));
 
 
     Arrays.stream(etSchemaPairs).

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
@@ -70,7 +70,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       RateLimitException, NakadiException {
     //todo:filebug: nakadi.event_stream.read is in the yaml but this is a write action
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -82,7 +82,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, ConflictException, NakadiException {
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -189,7 +189,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
         .path(SubscriptionResourceReal.PATH_CURSORS)
         .buildString();
 
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
 
     options.header(StreamResourceSupport.X_NAKADI_STREAM_ID, streamId);
 
@@ -284,7 +284,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
     final Resource resource = client.resourceProvider().newResource().retryPolicy(retryPolicy);
     final String url = collectionUri().path(id).path(PATH_CURSORS).buildString();
     // read scope: see https://github.com/zalando/nakadi/issues/648
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     final List<Cursor> cleaned = Cursor.prepareRequiringEventType(cursors);
 
     return timed(() ->

--- a/nakadi-java-client/src/main/resources/nakadi-envelope-schema/batch.publishing.avsc
+++ b/nakadi-java-client/src/main/resources/nakadi-envelope-schema/batch.publishing.avsc
@@ -1,0 +1,16 @@
+{
+  "name": "PublishingBatch",
+  "namespace": "org.zalando.nakadi.generated.avro",
+  "type": "record",
+  "fields": [
+    {
+      "name": "events",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "Envelope"
+        }
+      }
+    }
+  ]
+}

--- a/nakadi-java-client/src/main/resources/nakadi-envelope-schema/envelope.avsc
+++ b/nakadi-java-client/src/main/resources/nakadi-envelope-schema/envelope.avsc
@@ -1,0 +1,129 @@
+{
+  "name": "Envelope",
+  "namespace": "org.zalando.nakadi.generated.avro",
+  "type": "record",
+  "fields": [
+    {
+      "name": "metadata",
+      "type": {
+        "name": "Metadata",
+        "type": "record",
+        "doc": "Event metadata defines data about the payload and additional information for Nakadi operations",
+        "fields": [
+          {
+            "name": "occurred_at",
+            "type": {
+              "type": "long",
+              "logicalType": "timestamp-millis"
+            }
+          },
+          {
+            "name": "eid",
+            "type": {
+              "type": "string",
+              "logicalType": "uuid"
+            }
+          },
+          {
+            "name": "flow_id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "received_at",
+            "type": [
+              "null",
+              {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "published_by",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "event_type",
+            "type": "string"
+          },
+          {
+            "name": "partition",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "partition_keys",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": "string"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "partition_compaction_key",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "parent_eids",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "logicalType": "uuid"
+                }
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "span_ctx",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "event_owner",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "payload",
+      "type": {
+        "type": "bytes"
+      }
+    }
+  ]
+}

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
@@ -1,19 +1,63 @@
 package nakadi;
 
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.avro.Schema;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.junit.Test;
 import org.zalando.nakadi.generated.avro.PublishingBatch;
 import org.zalando.nakadi.generated.avro.test.SomeEvent;
 
+import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.spy;
 
-public class EventResourceRealBinaryTest extends EventResourceRealTest {
+public class EventResourceRealBinaryTest {
+
+    public static final int MOCK_SERVER_PORT = 8317;
+
+    MockWebServer server = new MockWebServer();
+    GsonSupport json = new GsonSupport();
+
+    public void before() {
+        try {
+            server.start(InetAddress.getByName("localhost"), MOCK_SERVER_PORT);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void after() {
+        try {
+            server.shutdown();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void exceptionOnMismatchSchema(){
+        final NakadiClient client = spy(NakadiClient.newBuilder()
+                .baseURI("http://localhost:" + MOCK_SERVER_PORT)
+                .build());
+        try {
+            before();
+            server.enqueue(new MockResponse().setResponseCode(404));
+            Exception ex = assertThrows(InvalidSchemaException.class, () ->
+                    client.resources().eventsBinary(
+                            new EventTypeSchemaPair<Schema>().eventTypeName("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF").version("2.0.0").schema(SomeEvent.getClassSchema()))) ;
+
+            assertEquals("No matching schemas found for event types [2C0A51FD-32ED-4FF4-8528-283F6B4C35EF]", ex.getMessage());
+        }finally {
+            after();
+        }
+    }
 
     @Test
     public void sendBinaryEvent() throws Exception {
@@ -21,11 +65,6 @@ public class EventResourceRealBinaryTest extends EventResourceRealTest {
                 .baseURI("http://localhost:" + MOCK_SERVER_PORT)
                 .build());
 
-        final EventResource resource = client.resources().eventsBinary(
-                "2C0A51FD-32ED-4FF4-8528-283F6B4C35EF",
-                "1.0.0",
-                SomeEvent.getClassSchema()
-        );
 
         final SomeEvent someEvent = SomeEvent.newBuilder()
                 .setFoo(100)
@@ -36,12 +75,24 @@ public class EventResourceRealBinaryTest extends EventResourceRealTest {
                 EventMetadata.newPreparedEventMetadata()
                         .eventType("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF")
                         .version("1.0.0"));
+        EventTypeSchema eventTypeSchemaResponse = new EventTypeSchema().
+                schema(SomeEvent.getClassSchema().toString()).
+                version("1.0.0").
+                type(EventTypeSchema.Type.avro_schema);
 
         try {
             before();
-
+            server.enqueue(new MockResponse().setResponseCode(200).setBody(json.toJson(eventTypeSchemaResponse)));
+            final EventResource resource = client.resources().eventsBinary(
+                    new EventTypeSchemaPair<Schema>().eventTypeName("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF").
+                            version("1.0.0").
+                            schema(SomeEvent.getClassSchema())
+            );
+            server.takeRequest();
             server.enqueue(new MockResponse().setResponseCode(200));
+
             resource.send("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF", envelope);
+
             final RecordedRequest request = server.takeRequest();
             assertEquals(
                     "POST /event-types/2C0A51FD-32ED-4FF4-8528-283F6B4C35EF/events HTTP/1.1",
@@ -59,4 +110,47 @@ public class EventResourceRealBinaryTest extends EventResourceRealTest {
             after();
         }
     }
+
+    @Test
+    public void failSendOnIncorrectEventTypeInMetadata() throws Exception {
+        final NakadiClient client = spy(NakadiClient.newBuilder()
+                .baseURI("http://localhost:" + MOCK_SERVER_PORT)
+                .build());
+
+
+        final SomeEvent someEvent = SomeEvent.newBuilder()
+                .setFoo(100)
+                .setFoo2("bar")
+                .build();
+
+        final EventEnvelope<SomeEvent> envelope = new EventEnvelope(someEvent,
+                EventMetadata.newPreparedEventMetadata()
+                        .eventType("dummy-event-type")
+                        .version("1.0.0"));
+        EventTypeSchema eventTypeSchemaResponse = new EventTypeSchema().
+                schema(SomeEvent.getClassSchema().toString()).
+                version("1.0.0").
+                type(EventTypeSchema.Type.avro_schema);
+
+        try {
+            before();
+            server.enqueue(new MockResponse().setResponseCode(200).setBody(json.toJson(eventTypeSchemaResponse)));
+            final EventResource resource = client.resources().eventsBinary(
+                    new EventTypeSchemaPair<Schema>().eventTypeName("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF").
+                            version("1.0.0").
+                            schema(SomeEvent.getClassSchema())
+            );
+            server.takeRequest();
+            server.enqueue(new MockResponse().setResponseCode(200));
+
+            Exception ex = assertThrows(InvalidEventTypeException.class, () ->
+                    resource.send("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF", envelope)
+            );
+            assertEquals("Unexpected event-type dummy-event-type provided during avro serialization", ex.getMessage());
+
+        } finally {
+            after();
+        }
+    }
+
 }

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
@@ -1,0 +1,65 @@
+package nakadi;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.junit.Test;
+import org.zalando.nakadi.generated.avro.Envelope;
+import org.zalando.nakadi.generated.avro.PublishingBatch;
+import org.zalando.nakadi.generated.avro.test.SomeEvent;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+
+public class EventResourceRealBinaryTest extends EventResourceRealTest {
+
+    @Test
+    public void sendBinaryEvent() throws Exception {
+        final NakadiClient client = spy(NakadiClient.newBuilder()
+                .baseURI("http://localhost:" + MOCK_SERVER_PORT)
+                .build());
+
+        final EventResource resource = client.resources().eventsBinary(
+                "2C0A51FD-32ED-4FF4-8528-283F6B4C35EF",
+                "1.0.0",
+                SomeEvent.getClassSchema()
+        );
+
+        final SomeEvent someEvent = SomeEvent.newBuilder()
+                .setFoo(100)
+                .setFoo2("bar")
+                .build();
+
+        final EventEnvelope<SomeEvent> envelope = new EventEnvelope(someEvent,
+                EventMetadata.newPreparedEventMetadata()
+                        .eventType("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF")
+                        .version("1.0.0"));
+
+        try {
+            before();
+
+            server.enqueue(new MockResponse().setResponseCode(200));
+            resource.send("2C0A51FD-32ED-4FF4-8528-283F6B4C35EF", envelope);
+            final RecordedRequest request = server.takeRequest();
+            assertEquals(
+                    "POST /event-types/2C0A51FD-32ED-4FF4-8528-283F6B4C35EF/events HTTP/1.1",
+                    request.getRequestLine());
+//            assertEquals("application/avro-binary", request.getHeaders().get("Content-Type"));
+
+            final PublishingBatch actualBatch = PublishingBatch.fromByteBuffer(
+                    ByteBuffer.wrap(request.getBody().readByteArray()));
+
+            final SomeEvent actualEvent = new SpecificDatumReader<SomeEvent>(SomeEvent.getClassSchema())
+                    .read(null, DecoderFactory.get().binaryDecoder(
+                            actualBatch.getEvents().get(0).getPayload().array(), null));
+            assertEquals(someEvent, actualEvent);
+        } finally {
+            after();
+        }
+    }
+}

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
@@ -152,5 +152,4 @@ public class EventResourceRealBinaryTest {
             after();
         }
     }
-
 }

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealBinaryTest.java
@@ -2,12 +2,9 @@ package nakadi;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.junit.Test;
-import org.zalando.nakadi.generated.avro.Envelope;
 import org.zalando.nakadi.generated.avro.PublishingBatch;
 import org.zalando.nakadi.generated.avro.test.SomeEvent;
 
@@ -49,7 +46,7 @@ public class EventResourceRealBinaryTest extends EventResourceRealTest {
             assertEquals(
                     "POST /event-types/2C0A51FD-32ED-4FF4-8528-283F6B4C35EF/events HTTP/1.1",
                     request.getRequestLine());
-//            assertEquals("application/avro-binary", request.getHeaders().get("Content-Type"));
+            assertEquals("application/avro-binary", request.getHeaders().get("Content-Type"));
 
             final PublishingBatch actualBatch = PublishingBatch.fromByteBuffer(
                     ByteBuffer.wrap(request.getBody().readByteArray()));

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
@@ -453,7 +453,7 @@ public class EventResourceRealTest {
     EventThing et = new EventThing("a", "b");
     EventRecord<EventThing> er = new EventRecord<>("topic", et);
 
-    Object o = eventResource.mapEventRecordToSerdes(er);
+    Object o = new GsonSupport().transformEventRecord(er);
 
     assertEquals(et, o);
   }
@@ -467,7 +467,7 @@ public class EventResourceRealTest {
     UndefinedEventMapped<Map<String, Object>> ue =
         new UndefinedEventMapped<Map<String, Object>>().data(uemap);
     EventRecord<UndefinedEventMapped> er = new EventRecord<>("topic", ue);
-    Map<String, Object> outmap = (Map<String, Object>) eventResource.mapEventRecordToSerdes(er);
+    Map<String, Object> outmap = (Map<String, Object>)  new GsonSupport().transformEventRecord(er);
     assertTrue(outmap.size() == 1);
     assertTrue(outmap.containsKey("a"));
     assertEquals("1", outmap.get("a"));
@@ -489,7 +489,7 @@ public class EventResourceRealTest {
     be.metadata(em);
 
     EventRecord<BusinessEventMapped> er = new EventRecord<>("topic", be);
-    JsonObject outmap = (JsonObject) eventResource.mapEventRecordToSerdes(er);
+    JsonObject outmap = (JsonObject) new GsonSupport().transformEventRecord(er);
     assertTrue(outmap.size() == 5);
     assertTrue(outmap.get("metadata") != null);
     assertTrue(outmap.get("a") != null);

--- a/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
@@ -14,7 +14,6 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -112,7 +111,7 @@ public class OkHttpResourceTest {
       try {
         server.enqueue(new MockResponse().setResponseCode(entry.getKey()));
 
-        buildResource().requestThrowing("POST", baseUrl(), buildOptions(), () -> json.toJsonBytes("{}"));
+        buildResource().requestThrowing("POST", baseUrl(), buildOptionsWithJsonContent(), () -> json.toJsonBytes("{}"));
         fail("expected exception for " + entry.getValue());
 
       } catch (NakadiException e) {
@@ -145,7 +144,7 @@ public class OkHttpResourceTest {
       try {
         server.enqueue(new MockResponse().setResponseCode(entry.getKey()));
 
-        buildResource().requestThrowing("POST", baseUrl(), buildOptions(), () -> json.toJsonBytes("{}"), String.class);
+        buildResource().requestThrowing("POST", baseUrl(), buildOptionsWithJsonContent(), () -> json.toJsonBytes("{}"), String.class);
         fail("expected exception for " + entry.getValue());
       } catch (NakadiException e) {
         assertEquals(entry.getValue(), e.getClass());
@@ -164,7 +163,7 @@ public class OkHttpResourceTest {
     Subscription response = buildResource().requestThrowing(
         "POST",
         baseUrl(),
-        buildOptions(),
+        buildOptionsWithJsonContent(),
         () -> json.toJsonBytes(request),
         Subscription.class);
 
@@ -173,6 +172,11 @@ public class OkHttpResourceTest {
 
   private ResourceOptions buildOptions() {
     return ResourceSupport.options("application/json").tokenProvider(scope -> Optional.empty());
+  }
+
+  private ResourceOptions buildOptionsWithJsonContent() {
+    return ResourceSupport.
+            optionsWithJsonContent(ResourceSupport.options("application/json").tokenProvider(scope -> Optional.empty()));
   }
 
   private Map<Integer, Class> responseCodesToExceptions() {
@@ -377,7 +381,7 @@ public class OkHttpResourceTest {
     server.enqueue(new MockResponse().setResponseCode(200));
 
     OkHttpResource r = buildResource();
-    ResourceOptions options = buildOptions();
+    ResourceOptions options = buildOptionsWithJsonContent();
 
     Subscription subscription = buildSubscription();
 
@@ -553,7 +557,7 @@ public class OkHttpResourceTest {
   public void requestThrowingBody() throws Exception {
 
     OkHttpResource r = buildResource();
-    ResourceOptions options = buildOptions();
+    ResourceOptions options = buildOptionsWithJsonContent();
     server.enqueue(new MockResponse().setResponseCode(200));
 
     Subscription subscription = buildSubscription();

--- a/nakadi-java-client/src/test/resources/avro-schemas/2C0A51FD-32ED-4FF4-8528-283F6B4C35EF.avsc
+++ b/nakadi-java-client/src/test/resources/avro-schemas/2C0A51FD-32ED-4FF4-8528-283F6B4C35EF.avsc
@@ -1,0 +1,15 @@
+{
+  "name": "SomeEvent",
+  "namespace": "org.zalando.nakadi.generated.avro.test",
+  "type": "record",
+  "fields": [
+    {
+      "name": "foo",
+      "type": "long"
+    },
+    {
+      "name": "foo2",
+      "type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
This PR is part of the effort to introduce Avro capability. In this first PR, Avro publishing feature has implemented.

1. The public API for publishing is kept decoupled from Avro. 
2. The initialization for Avro `EventResource` is done from `Resources.eventsBinary(..)` method which first performs check whether the supplied event type schemas exist. It also fetches the version from Nakadi and later populate it in version field of `EventMetadata` automatically.
3. A New abstraction called `PayloadSerializer` is introduced that takes care of serialization and holding `Content Type` information. Currently 2 implementations `JsonPayloadSerializer` and `AvroPayloadSerializer` exist and more can be added as desired later.
4. Due to new `Content Type`, the `Content Type` information for every POST/PUT request needs to be passed.