### PR TITLE
Supply content type from headers

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
@@ -223,6 +223,7 @@ public class EventResourceReal implements EventResource {
           options.flowId(flowId);
       }
       options.headers(headers);
+      ResourceSupport.optionsWithJsonContent(options);
       return options;
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
@@ -54,7 +54,7 @@ class EventTypeResourceReal implements EventTypeResource {
       RateLimitException, NakadiException {
 
     // todo: close
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -66,7 +66,7 @@ class EventTypeResourceReal implements EventTypeResource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, NakadiException {
     String url = collectionUri().path(eventType.name()).buildString();
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     // todo: close
     return client.resourceProvider()
         .newResource()
@@ -159,7 +159,7 @@ class EventTypeResourceReal implements EventTypeResource {
     NakadiException.throwNotNullOrEmpty(cursorList, "Please provide at least one cursor");
 
     final String url = collectionUri().path(eventTypeName).path(PATH_CURSOR_SHIFTS).buildString();
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     final Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -177,7 +177,7 @@ class EventTypeResourceReal implements EventTypeResource {
       String eventTypeName, List<CursorDistance> cursorDistanceList) {
 
     final String url = collectionUri().path(eventTypeName).path(PATH_CURSOR_DISTANCE).buildString();
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     final Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -192,7 +192,7 @@ class EventTypeResourceReal implements EventTypeResource {
 
   @Override public PartitionCollection lag(String eventTypeName, List<Cursor> cursors) {
     final String url = collectionUri().path(eventTypeName).path("cursors-lag").buildString();
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
 
     final Response response = client.resourceProvider()
         .newResource()

--- a/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
@@ -21,7 +21,6 @@ class OkHttpResource implements Resource {
   private static final Logger logger = LoggerFactory.getLogger(NakadiClient.class.getSimpleName());
 
   private static final String HEADER_AUTHORIZATION = "Authorization";
-  private static final String APPLICATION_JSON_CHARSET_UTF8 = "application/json; charset=utf8";
 
   private final OkHttpClient okHttpClient;
   private final JsonSupport jsonSupport;
@@ -198,7 +197,8 @@ class OkHttpResource implements Resource {
     if (body != null) {
       {
         RequestBody requestBody =
-            RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF8), body.content());
+                RequestBody.create(MediaType.parse((String) options.headers().get("Content-Type")), body.content());
+
         builder = new Request.Builder().url(url).method(method, requestBody);
       }
     } else {

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -21,4 +21,9 @@ class ResourceSupport {
         .header("User-Agent", NakadiClient.USER_AGENT)
         .flowId(ResourceSupport.nextFlowId());
   }
+
+  public static ResourceOptions optionsWithJsonContent(ResourceOptions options) {
+    return options.header("Content-Type", "application/json; charset=utf8");
+  }
+
 }

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
@@ -70,7 +70,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       RateLimitException, NakadiException {
     //todo:filebug: nakadi.event_stream.read is in the yaml but this is a write action
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -82,7 +82,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, ConflictException, NakadiException {
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -189,7 +189,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
         .path(SubscriptionResourceReal.PATH_CURSORS)
         .buildString();
 
-    ResourceOptions options = prepareOptions();
+    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
 
     options.header(StreamResourceSupport.X_NAKADI_STREAM_ID, streamId);
 
@@ -284,7 +284,7 @@ class SubscriptionResourceReal implements SubscriptionResource {
     final Resource resource = client.resourceProvider().newResource().retryPolicy(retryPolicy);
     final String url = collectionUri().path(id).path(PATH_CURSORS).buildString();
     // read scope: see https://github.com/zalando/nakadi/issues/648
-    final ResourceOptions options = prepareOptions();
+    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
     final List<Cursor> cleaned = Cursor.prepareRequiringEventType(cursors);
 
     return timed(() ->

--- a/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
@@ -112,7 +112,7 @@ public class OkHttpResourceTest {
       try {
         server.enqueue(new MockResponse().setResponseCode(entry.getKey()));
 
-        buildResource().requestThrowing("POST", baseUrl(), buildOptions(), () -> json.toJsonBytes("{}"));
+          buildResource().requestThrowing("POST", baseUrl(), buildOptionsWithJsonContent(), () -> json.toJsonBytes("{}"));
         fail("expected exception for " + entry.getValue());
 
       } catch (NakadiException e) {
@@ -145,7 +145,7 @@ public class OkHttpResourceTest {
       try {
         server.enqueue(new MockResponse().setResponseCode(entry.getKey()));
 
-        buildResource().requestThrowing("POST", baseUrl(), buildOptions(), () -> json.toJsonBytes("{}"), String.class);
+        buildResource().requestThrowing("POST", baseUrl(), buildOptionsWithJsonContent(), () -> json.toJsonBytes("{}"), String.class);
         fail("expected exception for " + entry.getValue());
       } catch (NakadiException e) {
         assertEquals(entry.getValue(), e.getClass());
@@ -164,7 +164,7 @@ public class OkHttpResourceTest {
     Subscription response = buildResource().requestThrowing(
         "POST",
         baseUrl(),
-        buildOptions(),
+        buildOptionsWithJsonContent(),
         () -> json.toJsonBytes(request),
         Subscription.class);
 
@@ -173,6 +173,11 @@ public class OkHttpResourceTest {
 
   private ResourceOptions buildOptions() {
     return ResourceSupport.options("application/json").tokenProvider(scope -> Optional.empty());
+  }
+
+  private ResourceOptions buildOptionsWithJsonContent() {
+    return ResourceSupport.
+            optionsWithJsonContent(ResourceSupport.options("application/json").tokenProvider(scope -> Optional.empty()));
   }
 
   private Map<Integer, Class> responseCodesToExceptions() {
@@ -377,7 +382,7 @@ public class OkHttpResourceTest {
     server.enqueue(new MockResponse().setResponseCode(200));
 
     OkHttpResource r = buildResource();
-    ResourceOptions options = buildOptions();
+    ResourceOptions options = buildOptionsWithJsonContent();
 
     Subscription subscription = buildSubscription();
 
@@ -553,7 +558,7 @@ public class OkHttpResourceTest {
   public void requestThrowingBody() throws Exception {
 
     OkHttpResource r = buildResource();
-    ResourceOptions options = buildOptions();
+    ResourceOptions options = buildOptionsWithJsonContent();
     server.enqueue(new MockResponse().setResponseCode(200));
 
     Subscription subscription = buildSubscription();


### PR DESCRIPTION
The content type for post requests is always `application/json`, to make it dynamic now its read from headers. This will enable in future to add body with different content type.