### PR TITLE
Making room for more flexible content type handling

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/ResourceOptions.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceOptions.java
@@ -6,6 +6,10 @@ import java.util.Optional;
 
 class ResourceOptions {
 
+  static final String HEADER_ACCEPT = "Accept";
+  static final String HEADER_ACCEPT_CHARSET = "Accept-Charset";
+  static final String HEADER_CONTENT_TYPE = "Content-Type";
+
   //multimap would be correct, but a client for this api doesn't setting multiple same headers
   private final Map<String, Object> headers = new HashMap<>();
   private TokenProvider provider;
@@ -28,6 +32,40 @@ class ResourceOptions {
     this.headers.putAll(headers);
     return this;
   }
+
+  /**
+   * Convenience method to set the Accept header for the request.
+   *
+   * @param accept the value of the Content-Type header
+   * @return this updated
+   */
+  public ResourceOptions accept(String accept) {
+    this.header(HEADER_ACCEPT, accept);
+    return this;
+  }
+
+  /**
+   * Convenience method to set the Accept Charset header for the request.
+   *
+   * @param charset the value of the Content-Type header
+   * @return this updated
+   */
+  public ResourceOptions acceptCharset(String charset) {
+    this.header(HEADER_ACCEPT_CHARSET, charset);
+    return this;
+  }
+
+  /**
+   * Convenience method to set the Content-Type header for the request.
+   *
+   * @param contentType the value of the Content-Type header
+   * @return this updated
+   */
+  public ResourceOptions contentType(String contentType) {
+    this.header(HEADER_CONTENT_TYPE, contentType);
+    return this;
+  }
+
 
   /**
    * Deprecated since 0.9.7 and will be removed in 0.10.0.

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ThreadLocalRandom;
 class ResourceSupport {
 
   public static final String CHARSET_UTF_8 = "UTF-8";
+  public static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json; charset=utf8";
 
   static String nextEid() {
     return UUID.randomUUID().toString();
@@ -25,7 +26,7 @@ class ResourceSupport {
   }
 
   public static ResourceOptions optionsWithJsonContent(ResourceOptions options) {
-    return options.header("Content-Type", "application/json; charset=utf8");
+    return options.header("Content-Type", APPLICATION_JSON_CHARSET_UTF_8);
   }
 
 }

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -5,6 +5,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 class ResourceSupport {
 
+  public static final String CHARSET_UTF_8 = "UTF-8";
+
   static String nextEid() {
     return UUID.randomUUID().toString();
   }
@@ -17,7 +19,7 @@ class ResourceSupport {
   public static ResourceOptions options(String accept) {
     return new ResourceOptions()
         .header("Accept", accept)
-        .header("Accept-Charset", "UTF-8")
+        .header("Accept-Charset", CHARSET_UTF_8)
         .header("User-Agent", NakadiClient.USER_AGENT)
         .flowId(ResourceSupport.nextFlowId());
   }

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -20,14 +20,14 @@ class ResourceSupport {
 
   public static ResourceOptions options(String accept) {
     return new ResourceOptions()
-        .header("Accept", accept)
-        .header("Accept-Charset", CHARSET_UTF_8)
+        .header(ResourceOptions.HEADER_ACCEPT, accept)
+        .header(ResourceOptions.HEADER_ACCEPT_CHARSET, CHARSET_UTF_8)
         .header("User-Agent", NakadiClient.USER_AGENT)
         .flowId(ResourceSupport.nextFlowId());
   }
 
   public static ResourceOptions optionsWithJsonContent(ResourceOptions options) {
-    return options.header("Content-Type", APPLICATION_JSON_CHARSET_UTF_8);
+    return options.header(ResourceOptions.HEADER_CONTENT_TYPE, APPLICATION_JSON_CHARSET_UTF_8);
   }
 
 }

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -6,7 +6,8 @@ import java.util.concurrent.ThreadLocalRandom;
 class ResourceSupport {
 
   public static final String CHARSET_UTF_8 = "UTF-8";
-  public static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json; charset=utf8";
+  public static final String APPLICATION_JSON_CHARSET_UTF_8 =
+      "application/json; charset=" + CHARSET_UTF_8;
 
   static String nextEid() {
     return UUID.randomUUID().toString();

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
@@ -252,7 +252,7 @@ public class EventResourceRealTest {
       RecordedRequest request = server.takeRequest();
 
       assertEquals("POST /event-types/ue-1-1479125860/events HTTP/1.1", request.getRequestLine());
-      assertEquals("application/json; charset=utf8", request.getHeaders().get("Content-Type"));
+      assertEquals(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8, request.getHeaders().get("Content-Type"));
       assertEquals(NakadiClient.USER_AGENT, request.getHeaders().get("User-Agent"));
       TestCase.assertTrue(request.getHeaders().get("X-Flow-Id") != null);
 
@@ -311,7 +311,7 @@ public class EventResourceRealTest {
       RecordedRequest request = server.takeRequest();
 
       assertEquals("POST /event-types/be-1-1479125860/events HTTP/1.1", request.getRequestLine());
-      assertEquals("application/json; charset=utf8", request.getHeaders().get("Content-Type"));
+      assertEquals(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8, request.getHeaders().get("Content-Type"));
       assertEquals(NakadiClient.USER_AGENT, request.getHeaders().get("User-Agent"));
       TestCase.assertTrue(request.getHeaders().get("X-Flow-Id") != null);
 

--- a/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
@@ -390,7 +390,7 @@ public class OkHttpResourceTest {
     RecordedRequest request = server.takeRequest();
 
     assertEquals("POST /subscriptions HTTP/1.1", request.getRequestLine());
-    assertEquals("application/json; charset=utf8", request.getHeaders().get("Content-Type"));
+    assertEquals(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8, request.getHeaders().get("Content-Type"));
     assertEquals(NakadiClient.USER_AGENT, request.getHeaders().get("User-Agent"));
     assertTrue(request.getHeaders().get("X-Flow-Id") != null);
 
@@ -568,7 +568,7 @@ public class OkHttpResourceTest {
     RecordedRequest request = server.takeRequest();
 
     assertEquals("POST /subscriptions HTTP/1.1", request.getRequestLine());
-    assertEquals("application/json; charset=utf8", request.getHeaders().get("Content-Type"));
+    assertEquals(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8, request.getHeaders().get("Content-Type"));
     assertEquals(NakadiClient.USER_AGENT, request.getHeaders().get("User-Agent"));
     assertTrue(request.getHeaders().get("X-Flow-Id") != null);
 

--- a/nakadi-java-client/src/test/java/nakadi/ResourceOptionsTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ResourceOptionsTest.java
@@ -1,0 +1,30 @@
+package nakadi;
+
+import junit.framework.TestCase;
+
+public class ResourceOptionsTest extends TestCase {
+
+  public void testContentType() {
+
+    ResourceOptions options = new ResourceOptions();
+    String ctype = "application/foo";
+    options.contentType(ctype);
+    assertEquals(options.headers().get(ResourceOptions.HEADER_CONTENT_TYPE), ctype);
+  }
+
+  public void testAccept() {
+
+    ResourceOptions options = new ResourceOptions();
+    String accept = "application/bar";
+    options.accept(accept);
+    assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT), accept);
+  }
+
+  public void testAcceptCharset() {
+
+    ResourceOptions options = new ResourceOptions();
+    String cset = "UTF-9";
+    options.acceptCharset(cset);
+    assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT_CHARSET), cset);
+  }
+}

--- a/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
@@ -25,7 +25,7 @@ public class ResourceSupportTest extends TestCase {
     assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT), accept);
 
     assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT_CHARSET),
-        "UTF-8");
+        ResourceSupport.CHARSET_UTF_8);
 
     assertNull(options.headers().get(ResourceOptions.HEADER_CONTENT_TYPE));
 

--- a/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
@@ -32,6 +32,6 @@ public class ResourceSupportTest extends TestCase {
     ResourceOptions options1 = ResourceSupport.optionsWithJsonContent(options);
 
     assertEquals(options1.headers().get(ResourceOptions.HEADER_CONTENT_TYPE),
-        "application/json; charset=utf8");
+        ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
   }
 }

--- a/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
@@ -1,0 +1,37 @@
+package nakadi;
+
+import junit.framework.TestCase;
+
+public class ResourceSupportTest extends TestCase {
+
+  public void testOptions() {
+
+    String accept = "application/bar";
+    ResourceOptions options = ResourceSupport.options(accept);
+
+    assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT), accept);
+
+    assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT_CHARSET),
+        "UTF-8");
+
+    assertNull(options.headers().get(ResourceOptions.HEADER_CONTENT_TYPE));
+  }
+
+  public void testOptionsWithJsonContent() {
+
+    String accept = "application/foo";
+    ResourceOptions options = ResourceSupport.options(accept);
+
+    assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT), accept);
+
+    assertEquals(options.headers().get(ResourceOptions.HEADER_ACCEPT_CHARSET),
+        "UTF-8");
+
+    assertNull(options.headers().get(ResourceOptions.HEADER_CONTENT_TYPE));
+
+    ResourceOptions options1 = ResourceSupport.optionsWithJsonContent(options);
+
+    assertEquals(options1.headers().get(ResourceOptions.HEADER_CONTENT_TYPE),
+        "application/json; charset=utf8");
+  }
+}

--- a/nakadi-java-client/src/test/java/nakadi/SubscriptionResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/SubscriptionResourceRealTest.java
@@ -101,7 +101,7 @@ public class SubscriptionResourceRealTest {
       final RecordedRequest request = server.takeRequest();
 
       assertEquals("PATCH /subscriptions/5-19/cursors HTTP/1.1", request.getRequestLine());
-      assertEquals("application/json; charset=utf8", request.getHeaders().get("Content-Type"));
+      assertEquals(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8, request.getHeaders().get("Content-Type"));
       assertEquals(NakadiClient.USER_AGENT, request.getHeaders().get("User-Agent"));
 
       final String body = request.getBody().readUtf8();


### PR DESCRIPTION
- Adds header convenience methods to ResourceOptions for clarity
- Adds tests to verify behaviour added in #379