### PR TITLE
Use convenience methods in place of header keys and values

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
@@ -222,9 +222,7 @@ public class EventResourceReal implements EventResource {
       if (flowId != null) {
           options.flowId(flowId);
       }
-      options.headers(headers);
-      ResourceSupport.optionsWithJsonContent(options);
-      return options;
+      return options.headers(headers).contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
   }
 
   private UriBuilder collectionUri(String topic) {

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
@@ -54,7 +54,8 @@ class EventTypeResourceReal implements EventTypeResource {
       RateLimitException, NakadiException {
 
     // todo: close
-    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -66,7 +67,8 @@ class EventTypeResourceReal implements EventTypeResource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, NakadiException {
     String url = collectionUri().path(eventType.name()).buildString();
-    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
     // todo: close
     return client.resourceProvider()
         .newResource()
@@ -159,7 +161,8 @@ class EventTypeResourceReal implements EventTypeResource {
     NakadiException.throwNotNullOrEmpty(cursorList, "Please provide at least one cursor");
 
     final String url = collectionUri().path(eventTypeName).path(PATH_CURSOR_SHIFTS).buildString();
-    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    final ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
     final Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -177,7 +180,8 @@ class EventTypeResourceReal implements EventTypeResource {
       String eventTypeName, List<CursorDistance> cursorDistanceList) {
 
     final String url = collectionUri().path(eventTypeName).path(PATH_CURSOR_DISTANCE).buildString();
-    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    final ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
     final Response response = client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -192,7 +196,8 @@ class EventTypeResourceReal implements EventTypeResource {
 
   @Override public PartitionCollection lag(String eventTypeName, List<Cursor> cursors) {
     final String url = collectionUri().path(eventTypeName).path("cursors-lag").buildString();
-    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    final ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
 
     final Response response = client.resourceProvider()
         .newResource()

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -25,9 +25,4 @@ class ResourceSupport {
         .header("User-Agent", NakadiClient.USER_AGENT)
         .flowId(ResourceSupport.nextFlowId());
   }
-
-  public static ResourceOptions optionsWithJsonContent(ResourceOptions options) {
-    return options.contentType(APPLICATION_JSON_CHARSET_UTF_8);
-  }
-
 }

--- a/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ResourceSupport.java
@@ -27,7 +27,7 @@ class ResourceSupport {
   }
 
   public static ResourceOptions optionsWithJsonContent(ResourceOptions options) {
-    return options.header(ResourceOptions.HEADER_CONTENT_TYPE, APPLICATION_JSON_CHARSET_UTF_8);
+    return options.contentType(APPLICATION_JSON_CHARSET_UTF_8);
   }
 
 }

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
@@ -70,7 +70,8 @@ class SubscriptionResourceReal implements SubscriptionResource {
       RateLimitException, NakadiException {
     //todo:filebug: nakadi.event_stream.read is in the yaml but this is a write action
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -82,7 +83,8 @@ class SubscriptionResourceReal implements SubscriptionResource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, ConflictException, NakadiException {
     NakadiException.throwNonNull(subscription, "Please provide a subscription");
-    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
     return client.resourceProvider()
         .newResource()
         .retryPolicy(retryPolicy)
@@ -189,7 +191,8 @@ class SubscriptionResourceReal implements SubscriptionResource {
         .path(SubscriptionResourceReal.PATH_CURSORS)
         .buildString();
 
-    ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
 
     options.header(StreamResourceSupport.X_NAKADI_STREAM_ID, streamId);
 
@@ -284,7 +287,8 @@ class SubscriptionResourceReal implements SubscriptionResource {
     final Resource resource = client.resourceProvider().newResource().retryPolicy(retryPolicy);
     final String url = collectionUri().path(id).path(PATH_CURSORS).buildString();
     // read scope: see https://github.com/zalando/nakadi/issues/648
-    final ResourceOptions options = ResourceSupport.optionsWithJsonContent(prepareOptions());
+    final ResourceOptions options = prepareOptions()
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
     final List<Cursor> cleaned = Cursor.prepareRequiringEventType(cursors);
 
     return timed(() ->

--- a/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/OkHttpResourceTest.java
@@ -176,8 +176,9 @@ public class OkHttpResourceTest {
   }
 
   private ResourceOptions buildOptionsWithJsonContent() {
-    return ResourceSupport.
-            optionsWithJsonContent(ResourceSupport.options("application/json").tokenProvider(scope -> Optional.empty()));
+    return ResourceSupport.options("application/json")
+        .contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8)
+        .tokenProvider(scope -> Optional.empty());
   }
 
   private Map<Integer, Class> responseCodesToExceptions() {

--- a/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ResourceSupportTest.java
@@ -29,9 +29,9 @@ public class ResourceSupportTest extends TestCase {
 
     assertNull(options.headers().get(ResourceOptions.HEADER_CONTENT_TYPE));
 
-    ResourceOptions options1 = ResourceSupport.optionsWithJsonContent(options);
+    options.contentType(ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
 
-    assertEquals(options1.headers().get(ResourceOptions.HEADER_CONTENT_TYPE),
+    assertEquals(options.headers().get(ResourceOptions.HEADER_CONTENT_TYPE),
         ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8);
   }
 }


### PR DESCRIPTION
This will let us expose the content type value in the context of the requesting method, instead of a fixed value inside the `optionsWithJsonContent` helper method. In turn that will set us up to be able to change the content type to something other than application/json.