### PR TITLE
Starts adding support for non json events

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,19 +36,23 @@ public class EventResourceReal implements EventResource {
   private boolean enablePublishingCompression;
 
   private final CompressionSupport compressionSupport;
+  private final SerializationSupport serializationSupport;
 
   public EventResourceReal(NakadiClient client) {
-    this(client, client.jsonSupport(), client.compressionSupport());
+    this(client, client.jsonSupport(), client.compressionSupport(), client.getSerializationSupport());
   }
 
-  @VisibleForTesting
-  EventResourceReal(NakadiClient client, JsonSupport jsonSupport, CompressionSupport compressionSupport) {
+  @VisibleForTesting EventResourceReal(NakadiClient client,
+      JsonSupport jsonSupport,
+      CompressionSupport compressionSupport,
+      SerializationSupport serializationSupport) {
     this.client = client;
     this.jsonSupport = jsonSupport;
     this.compressionSupport = compressionSupport;
     if(client != null && client.enablePublishingCompression()) {
       this.enablePublishingCompression = true;
     }
+    this.serializationSupport = serializationSupport;
   }
 
   private static Response timed(Supplier<Response> sender, NakadiClient client, int eventCount) {
@@ -109,18 +112,15 @@ public class EventResourceReal implements EventResource {
     NakadiException.throwNonNull(events, "Please provide one or more events");
     NakadiException.throwNonNull(headers, "Please provide some headers");
 
-    if (events.size() == 0) {
+    if (events.isEmpty()) {
       throw new NakadiException(Problem.localProblem("event send called with zero events", ""));
     }
 
-    List<EventRecord<T>> collect =
-        events.stream().map(e -> new EventRecord<>(eventTypeName, e)).collect(Collectors.toList());
-
-    if (collect.get(0).event() instanceof String) {
+    if (new ArrayList<>(events).get(0) instanceof String) {
       return sendUsingSupplier(eventTypeName,
           () -> ("[" + Joiner.on(",").join(events) + "]").getBytes(Charsets.UTF_8), headers);
     } else {
-      return sendBatchOfEvents(collect, headers);
+      return sendBatchOfEvents(eventTypeName, events, headers);
     }
   }
 
@@ -183,37 +183,27 @@ public class EventResourceReal implements EventResource {
                  1);
   }
 
-  private <T> Response sendBatchOfEvents(List<EventRecord<T>> events, Map<String, Object> headers) {
+  private <T> Response sendBatchOfEvents(String eventTypeName, Collection<T> events, Map<String, Object> headers) {
     NakadiException.throwNonNull(events, "Please provide one or more event records");
 
-    String topic = events.get(0).eventType();
-    List<Object> eventList =
-        events.stream().map(this::mapEventRecordToSerdes).collect(Collectors.toList());
-
-    ContentSupplier supplier;
+    final ContentSupplier supplier;
 
     if(enablePublishingCompression) {
-      supplier =  supplyObjectAsCompressedAndSetHeaders(eventList, headers);
+      supplier =  supplyObjectAsCompressedAndSetHeaders(eventTypeName, events,  headers);
     } else {
-      supplier = () -> jsonSupport.toJsonBytesCompressed(eventList);
+      supplier = () -> serializationSupport.serializePayload(client, eventTypeName, events);
     }
-
-    final ContentSupplier finalSupplier = supplier;
 
     // todo: close
     return timed(() -> client.resourceProvider()
                      .newResource()
                      .retryPolicy(retryPolicy)
                      .postEventsThrowing(
-                         collectionUri(topic).buildString(),
+                         collectionUri(eventTypeName).buildString(),
                          options(headers),
-                         finalSupplier),
+                         supplier),
               client,
-        eventList.size());
-  }
-
-  @VisibleForTesting <T> Object mapEventRecordToSerdes(EventRecord<T> er) {
-    return jsonSupport.transformEventRecord(er);
+        events.size());
   }
 
   private ResourceOptions options(Map<String, Object> headers) {
@@ -223,7 +213,7 @@ public class EventResourceReal implements EventResource {
           options.flowId(flowId);
       }
       options.headers(headers);
-      ResourceSupport.optionsWithJsonContent(options);
+      options.header(ResourceOptions.HEADER_CONTENT_TYPE, serializationSupport.contentType());
       return options;
   }
 
@@ -234,9 +224,9 @@ public class EventResourceReal implements EventResource {
         .path(PATH_COLLECTION);
   }
 
-  private <T> ContentSupplier supplyObjectAsCompressedAndSetHeaders(T sending, Map<String, Object> headers) {
-    final byte[] json = jsonSupport.toJsonBytesCompressed(sending);
-    return supplyBytesAsCompressedAndSetHeaders(json, headers);
+  private <T> ContentSupplier supplyObjectAsCompressedAndSetHeaders(String eventTypeName, Collection<T> sending, Map<String, Object> headers) {
+    final byte[] batchBytes = serializationSupport.serializePayload(client, eventTypeName, sending);
+    return supplyBytesAsCompressedAndSetHeaders(batchBytes, headers);
   }
 
   private <T> ContentSupplier supplyStringAsCompressedAndSetHeaders(String sending, Map<String, Object> headers) {
@@ -249,10 +239,10 @@ public class EventResourceReal implements EventResource {
   }
 
   private ContentSupplier supplyBytesAsCompressedAndSetHeaders(
-      byte[] json, Map<String, Object> headers) {
+      byte[] batchBytes, Map<String, Object> headers) {
 
     // force the compression outside the lambda to access the length
-    final byte[] compressed = compressionSupport.compress(json);
+    final byte[] compressed = compressionSupport.compress(batchBytes);
     ContentSupplier supplier = () -> compressed;
     headers.put("Content-Length", compressed.length);
     headers.put("Content-Encoding", compressionSupport.name());

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeSchema.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeSchema.java
@@ -30,6 +30,11 @@ public class EventTypeSchema {
     return this;
   }
 
+  public EventTypeSchema version(String version) {
+    this.version = version;
+    return this;
+  }
+
   /**
    * The version of the schema used to validate this event.
    *
@@ -71,6 +76,7 @@ public class EventTypeSchema {
   }
 
   public enum Type {
-    json_schema
+    json_schema,
+    avro_schema
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/JsonPublishingBatchSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/JsonPublishingBatchSerializer.java
@@ -1,0 +1,21 @@
+package nakadi;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class JsonPublishingBatchSerializer implements PublishingBatchSerializer {
+
+  private final JsonSupport jsonSupport;
+
+  public JsonPublishingBatchSerializer(final JsonSupport jsonSupport) {
+    this.jsonSupport = jsonSupport;
+  }
+
+  @Override
+  public <T> byte[] toBytes(SerializationContext context, Collection<T> events) {
+    return jsonSupport.toJsonBytesCompressed(events.stream()
+        .map(e -> new EventRecord<>(context.name(), e))
+        .map(jsonSupport::transformEventRecord)
+        .collect(Collectors.toList()));
+  }
+}

--- a/nakadi-java-client/src/main/java/nakadi/JsonSerializationSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/JsonSerializationSupport.java
@@ -1,0 +1,57 @@
+package nakadi;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class JsonSerializationSupport implements SerializationSupport {
+
+  private JsonPublishingBatchSerializer payloadSerializer;
+  private Map<String, SerializationContext> contextCache;
+
+  public JsonSerializationSupport(JsonPublishingBatchSerializer payloadSerializer) {
+    this.payloadSerializer = payloadSerializer;
+    this.contextCache = new ConcurrentHashMap<>();
+  }
+
+  public static SerializationSupport newInstance(JsonSupport jsonSupport) {
+    return new JsonSerializationSupport(new JsonPublishingBatchSerializer(jsonSupport));
+  }
+
+  @Override
+  public <T> byte[] serializePayload(NakadiClient client, String eventTypeName, Collection<T> events) {
+    SerializationContext context = contextCache.computeIfAbsent(eventTypeName, JsonSerializationContext::new);
+    return payloadSerializer.toBytes(context, events);
+  }
+
+  @Override
+  public String contentType() {
+    return ResourceSupport.APPLICATION_JSON_CHARSET_UTF_8;
+  }
+
+  private static class JsonSerializationContext implements SerializationContext {
+
+    private String eventTypeName;
+
+    public JsonSerializationContext(String eventTypeName) {
+      this.eventTypeName = eventTypeName;
+    }
+
+    @Override
+    public String name() {
+      return eventTypeName;
+    }
+
+    @Override
+    public String schema() {
+      throw new UnsupportedOperationException("Serialization Context does not use JSON schema");
+    }
+
+    @Override
+    public String version() {
+      throw new UnsupportedOperationException("Serialization Context does not use schema version");
+    }
+  }
+
+  ;
+}

--- a/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
+++ b/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
@@ -27,6 +27,7 @@ public class NakadiClient {
   private final String certificatePath;
   private final boolean enablePublishingCompression;
   private final CompressionSupport compressionSupport;
+  private final SerializationSupport serializationSupport;
 
   private NakadiClient(Builder builder) {
     NakadiException.throwNonNull(builder.baseURI, "Please provide a base URI.");
@@ -39,6 +40,7 @@ public class NakadiClient {
     this.certificatePath = builder.certificatePath;
     this.enablePublishingCompression = builder.enablePublishingCompression;
     this.compressionSupport = builder.compressionSupport;
+    this.serializationSupport = builder.serializationSupport;
   }
 
   /**
@@ -108,6 +110,10 @@ public class NakadiClient {
     return resources;
   }
 
+  public SerializationSupport getSerializationSupport() {
+    return serializationSupport;
+  }
+
   @SuppressWarnings("WeakerAccess")
   public static class Builder {
 
@@ -123,6 +129,7 @@ public class NakadiClient {
     private boolean enablePublishingCompression;
     private CompressionSupport compressionSupport;
     private String certificatePath;
+    private SerializationSupport serializationSupport;
 
     Builder() {
       connectTimeout = 20_000;
@@ -143,6 +150,10 @@ public class NakadiClient {
 
       if (jsonSupport == null) {
         jsonSupport = new GsonSupport();
+      }
+
+      if (serializationSupport == null) {
+        serializationSupport = JsonSerializationSupport.newInstance(jsonSupport);
       }
 
       if (compressionSupport == null) {
@@ -309,6 +320,11 @@ public class NakadiClient {
      */
     public Builder jsonSupport(JsonSupport jsonSupport) {
       this.jsonSupport = jsonSupport;
+      return this;
+    }
+
+    public Builder serializationSupport(SerializationSupport serializationSupport) {
+      this.serializationSupport = serializationSupport;
       return this;
     }
   }

--- a/nakadi-java-client/src/main/java/nakadi/PublishingBatchSerializer.java
+++ b/nakadi-java-client/src/main/java/nakadi/PublishingBatchSerializer.java
@@ -1,0 +1,9 @@
+package nakadi;
+
+import java.util.Collection;
+
+public interface PublishingBatchSerializer {
+
+  <T> byte[] toBytes(SerializationContext context, Collection<T> events);
+
+}

--- a/nakadi-java-client/src/main/java/nakadi/SerializationContext.java
+++ b/nakadi-java-client/src/main/java/nakadi/SerializationContext.java
@@ -1,0 +1,11 @@
+package nakadi;
+
+public interface SerializationContext {
+
+  String name();
+
+  String schema();
+
+  String version();
+
+}

--- a/nakadi-java-client/src/main/java/nakadi/SerializationSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/SerializationSupport.java
@@ -1,0 +1,11 @@
+package nakadi;
+
+import java.util.Collection;
+
+public interface SerializationSupport {
+
+  <T> byte[] serializePayload(NakadiClient client, String eventTypeName, Collection<T> events);
+
+  String contentType();
+
+}


### PR DESCRIPTION
This introduces some indirection to allow alternative (non-json)
serializers to be used. SerializationSupport is used by the client
to access a serializer, with JsonSerializationSupport providing the
current default for JSON payloads.