### PR TITLE
Provides an initial avro implementation.

### DIFF
--- a/nakadi-java-avro/src/main/java/nakadi/avro/AvroPublishingBatchSerializer.java
+++ b/nakadi-java-avro/src/main/java/nakadi/avro/AvroPublishingBatchSerializer.java
@@ -1,0 +1,85 @@
+package nakadi.avro;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.avro.AvroMapper;
+import com.fasterxml.jackson.dataformat.avro.AvroSchema;
+import nakadi.BusinessEventMapped;
+import nakadi.DataChangeEvent;
+import nakadi.EventMetadata;
+import nakadi.PublishingBatchSerializer;
+import nakadi.SerializationContext;
+import org.apache.avro.Schema;
+import org.zalando.nakadi.generated.avro.Envelope;
+import org.zalando.nakadi.generated.avro.Metadata;
+import org.zalando.nakadi.generated.avro.PublishingBatch;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * The serializer uses jackson extension to serialize business pojos to avro events.
+ */
+public class AvroPublishingBatchSerializer implements PublishingBatchSerializer {
+
+  private AvroMapper avroMapper;
+  private Map<String, ObjectWriter> objectWriterCache;
+
+  public AvroPublishingBatchSerializer(AvroMapper avroMapper) {
+    this.avroMapper = avroMapper;
+    this.objectWriterCache = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public <T> byte[] toBytes(SerializationContext context, Collection<T> events) {
+    try {
+      List<Envelope> envelops = events.stream()
+          .map(event -> toEnvelope(context, event))
+          .collect(Collectors.toList());
+      return PublishingBatch.newBuilder().setEvents(envelops)
+          .build().toByteBuffer().array();
+    } catch (IOException io) {
+      throw new RuntimeException(io);
+    }
+  }
+
+  private <T> Envelope toEnvelope(SerializationContext context, T event) {
+    try {
+      EventMetadata metadata;
+      Object data;
+      if (event instanceof BusinessEventMapped) {
+        metadata = ((BusinessEventMapped) event).metadata();
+        data = ((BusinessEventMapped) event).data();
+      } else if (event instanceof DataChangeEvent) {
+        metadata = ((DataChangeEvent) event).metadata();
+        data = ((DataChangeEvent) event).data();
+      } else {
+        throw new InvalidEventTypeException("Unexpected event category `" +
+            event.getClass() + "` provided during avro serialization");
+      }
+
+      byte[] eventBytes = objectWriterCache.computeIfAbsent(context.name(),
+              (et) -> avroMapper.writer(new AvroSchema(new Schema.Parser().parse(context.schema()))))
+          .writeValueAsBytes(data);
+
+      return Envelope.newBuilder()
+          .setMetadata(Metadata.newBuilder()
+              .setEventType(context.name()) // metadata.eventType ?
+              .setVersion(context.version())
+              .setOccurredAt(metadata.occurredAt().toInstant())
+              .setEid(metadata.eid())
+              .setPartition(metadata.partition())
+              .setPartitionCompactionKey(metadata.partitionCompactionKey())
+              .build())
+          .setPayload(ByteBuffer.wrap(eventBytes))
+          .build();
+    } catch (IOException io) {
+      throw new RuntimeException(io);
+    }
+  }
+
+}

--- a/nakadi-java-avro/src/main/java/nakadi/avro/AvroSerializationSupport.java
+++ b/nakadi-java-avro/src/main/java/nakadi/avro/AvroSerializationSupport.java
@@ -1,0 +1,71 @@
+package nakadi.avro;
+
+import com.fasterxml.jackson.dataformat.avro.AvroMapper;
+import nakadi.EventType;
+import nakadi.EventTypeSchema;
+import nakadi.NakadiClient;
+import nakadi.SerializationContext;
+import nakadi.SerializationSupport;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class AvroSerializationSupport implements SerializationSupport {
+
+  private final AvroPublishingBatchSerializer payloadSerializer;
+  private final Map<String, SerializationContext> contextCache;
+
+  public AvroSerializationSupport(AvroPublishingBatchSerializer payloadSerializer) {
+    this.payloadSerializer = payloadSerializer;
+    this.contextCache = new ConcurrentHashMap<>();
+  }
+
+  public static SerializationSupport newInstance() {
+    return new AvroSerializationSupport(new AvroPublishingBatchSerializer(new AvroMapper()));
+  }
+
+  @Override
+  public <T> byte[] serializePayload(NakadiClient client, String eventTypeName, Collection<T> events) {
+    SerializationContext context = contextCache.computeIfAbsent(
+        eventTypeName, (et) -> new AvroSerializationContext(
+            client.resources().eventTypes().findByName(et)));
+    return payloadSerializer.toBytes(context, events);
+  }
+
+  @Override
+  public String contentType() {
+    return "application/avro-binary";
+  }
+
+  private static class AvroSerializationContext implements SerializationContext {
+
+    private final EventType eventType;
+
+    private AvroSerializationContext(EventType eventType) {
+      if (eventType.schema().type() != EventTypeSchema.Type.avro_schema) {
+        throw new InvalidSchemaException(String.format(
+            "Event type `%s` schema is `%s`, but expected Avro",
+            eventType.name(), eventType.schema().type()));
+      }
+
+      this.eventType = eventType;
+    }
+
+    @Override
+    public String name() {
+      return eventType.name();
+    }
+
+    @Override
+    public String schema() {
+      return eventType.schema().schema();
+    }
+
+    @Override
+    public String version() {
+      return eventType.schema().version();
+    }
+
+  }
+}

--- a/nakadi-java-avro/src/test/java/nakadi/avro/AvroPublishingBatchSerializerTest.java
+++ b/nakadi-java-avro/src/test/java/nakadi/avro/AvroPublishingBatchSerializerTest.java
@@ -1,14 +1,134 @@
 package nakadi.avro;
 
+import com.fasterxml.jackson.dataformat.avro.AvroMapper;
+import com.fasterxml.jackson.dataformat.avro.AvroSchema;
+import nakadi.BusinessEventMapped;
+import nakadi.EventMetadata;
+import nakadi.SerializationContext;
+import org.apache.avro.Schema;
+import org.junit.Assert;
 import org.junit.Test;
+import org.zalando.nakadi.generated.avro.PublishingBatch;
 
-import static org.junit.Assert.assertEquals;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Objects;
 
 public class AvroPublishingBatchSerializerTest {
 
+  private final String schema = "{\"type\":\"record\",\"name\":\"BusinessPayload\",\"fields\":[{\"name\":\"a\",\"type\":[\"null\",\"string\"]},{\"name\":\"b\",\"type\":[\"null\",\"string\"]},{\"name\":\"id\",\"type\":[\"null\",\"string\"]}]}";
+
   @Test
-  public void test() {
-    assertEquals("a", "a");
+  public void testToBytes() throws IOException {
+    BusinessPayload bp = new BusinessPayload("22", "A", "B");
+    BusinessEventMapped<BusinessPayload> event =
+        new BusinessEventMapped<BusinessPayload>()
+            .metadata(EventMetadata.newPreparedEventMetadata())
+            .data(bp);
+
+    AvroPublishingBatchSerializer avroPublishingBatchSerializer = new AvroPublishingBatchSerializer(new AvroMapper());
+    byte[] bytesBatch = avroPublishingBatchSerializer.toBytes(
+        new TestSerializationContext("ad-2022-12-13", schema, "1.0.0"),
+        Collections.singletonList(event)
+    );
+
+    PublishingBatch publishingBatch = PublishingBatch.fromByteBuffer(ByteBuffer.wrap(bytesBatch));
+    byte[] eventBytes = publishingBatch.getEvents().get(0).getPayload().array();
+    BusinessPayload actual = new AvroMapper().reader(
+            new AvroSchema(new Schema.Parser().parse(schema)))
+        .readValue(eventBytes, BusinessPayload.class);
+
+    Assert.assertEquals(bp, actual);
   }
 
+  static class BusinessPayload {
+    String id;
+    String a;
+    String b;
+
+    public BusinessPayload() {
+    }
+
+    public BusinessPayload(String id, String a, String b) {
+      this.id = id;
+      this.a = a;
+      this.b = b;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getA() {
+      return a;
+    }
+
+    public void setA(String a) {
+      this.a = a;
+    }
+
+    public String getB() {
+      return b;
+    }
+
+    public void setB(String b) {
+      this.b = b;
+    }
+
+    @Override
+    public String toString() {
+      return "BusinessPayload{" + "id='" + id + '\'' +
+          ", a='" + a + '\'' +
+          ", b='" + b + '\'' +
+          '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      BusinessPayload that = (BusinessPayload) o;
+      return Objects.equals(id, that.id) &&
+          Objects.equals(a, that.a) &&
+          Objects.equals(b, that.b);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, a, b);
+    }
+  }
+
+  private class TestSerializationContext implements SerializationContext {
+
+    private String name;
+    private String schema;
+    private String version;
+
+    public TestSerializationContext(String name, String schema, String version) {
+      this.name = name;
+      this.schema = schema;
+      this.version = version;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public String schema() {
+      return schema;
+    }
+
+    @Override
+    public String version() {
+      return version;
+    }
+  }
 }


### PR DESCRIPTION
AvroSerializationSupport can be provide to the client to handle avro serialisation. The serialization targets avro binary rather than avro json formatting. AvroPublishingBatchSerializerTest shows business envelope serialisation with events pretty much identical to the tests in EventResourceRealTest from the main client module.

For development, the build will need to run once to create the generated avro files in the 'org.zalando.nakadi.*' package space.