### PR TITLE
0.19.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 ### Changes
 
+### 0.19.0
+
+- Fixes implementation of onStart for buffered observers [#391](https://github.com/dehora/nakadi-java/pull/391).  @fghibellini
+- Provides an avro module for binary publishing [#390](https://github.com/dehora/nakadi-java/pull/390). @adyach
+- Refactoring content type handling to enable alternate formats [#381](https://github.com/dehora/nakadi-java/pull/381).
+- Supply content type from headers to enable alternate formats [#379](https://github.com/dehora/nakadi-java/pull/379). @adyach, @samizzy
+- Fixes to Problem type Javadoc and adds a marshal_entity problem [#377](https://github.com/dehora/nakadi-java/pull/377).
+
 ### 0.18.0
 
 - Non-json payloads on error responses are handled [#364](https://github.com/dehora/nakadi-java/pull/364). @f-sander

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Status**
 
 - Build: [![CircleCI](https://circleci.com/gh/dehora/nakadi-java.svg?style=svg)](https://circleci.com/gh/dehora/nakadi-java)
-- Source Release: [0.18.0](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.18.0)
+- Source Release: [0.19.0](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.19.0)
 - Contact: [maintainers](https://github.com/zalando-incubator/nakadi-java/blob/master/MAINTAINERS)
 
 
@@ -727,7 +727,7 @@ and add the project declaration to `pom.xml`:
 <dependency>
   <groupId>net.dehora.nakadi</groupId>
   <artifactId>nakadi-java-client</artifactId>
-  <version>0.18.0</version>
+  <version>0.19.0</version>
 </dependency>
 ```
 ### Gradle
@@ -754,13 +754,13 @@ and add the project to the `dependencies` block in `build.gradle`:
 
 ```groovy
 dependencies {
-  implementation 'net.dehora.nakadi:nakadi-java-client:0.18.0'
+  implementation 'net.dehora.nakadi:nakadi-java-client:0.19.0'
 }  
 ```
 
 ```kotlin
 dependencies {
-  implementation("net.dehora.nakadi:nakadi-java-client:0.18.0")
+  implementation("net.dehora.nakadi:nakadi-java-client:0.19.0")
 }  
 ```
 
@@ -775,7 +775,7 @@ resolvers += Opts.resolver.sonatypeSnapshots
 and add the project to `libraryDependencies` in `build.sbt`:
 
 ```scala
-libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.18.0"
+libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.19.0"
 ```
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.18.0
+version=0.19.0
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/nakadi-java-client/src/main/java/nakadi/Version.java
+++ b/nakadi-java-client/src/main/java/nakadi/Version.java
@@ -2,5 +2,5 @@ package nakadi;
 
 public class Version {
 
-  public static final String VERSION = "0.18.0";
+  public static final String VERSION = "0.19.0";
 }


### PR DESCRIPTION
- Fixes implementation of onStart for buffered observers [#391](https://github.com/dehora/nakadi-java/pull/391).  @fghibellini
- Provides an avro module for binary publishing [#390](https://github.com/dehora/nakadi-java/pull/390). @adyach
- Refactoring content type handling to enable alternate formats [#381](https://github.com/dehora/nakadi-java/pull/381).
- Supply content type from headers to enable alternate formats [#379](https://github.com/dehora/nakadi-java/pull/379). @adyach, @samizzy
- Fixes to Problem type Javadoc and adds a marshal_entity problem [#377](https://github.com/dehora/nakadi-java/pull/377).
